### PR TITLE
javascript api doc

### DIFF
--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -161,13 +161,13 @@ Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas 
 instance = {
     section: "22",
     startTime: {
-        date: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
+        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆(1985, 10, 6, 21, 22, 27, 0)
     }
     ...
 }
 ```
 
-(Key name `date` is chosen because that's how JavaScript calls time).
+Date object is represented with the code how it would have been created in Sydney (AEDT) time.
 
 However, in the case the time relevent to the timezone is important, the token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime). Take a FIFA football match ticket as an example, `matchTime` attribute is a dictionary of two keys: `date` as a Date object, not containing timezone, and the raw value for GeneralizedTime which has the timezone in it.
 
@@ -176,7 +176,7 @@ instance = {
     section: "22",
     matchTime: {
         generalizedTime: "19851106210627-0500",
-        date: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
+        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆(1985, 10, 6, 21, 22, 27, 0)
     }
     ...
 }

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -151,9 +151,9 @@ token = {
 }
 ```
 
-There are two attributes that are not of a primivite type: `locked`, which represents the balance committed somehow (typically, to a state channel), and `expiry` which is how much the balance will disappear at certain date, typically used as an incentive for users to spend, the opposite incentive of Bitcoin.
+There are two attributes that are not of a primitive type: `locked`, which represents the balance committed somehow (typically, to a state channel), and `expiry` which is how much the balance will disappear at certain date, typically used as an incentive for users to spend, the opposite incentive of Bitcoin.
 
-What form of value do we have for each attribute is a result of the attrubte-type found in `tokenDefinition`.
+What form of value do we have for each attribute is a result of the attribute-type found in `tokenDefinition`.
 
 Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas efficiency, which is just binary encoded UnixTime. When used as the time of an event, there is no ambiguity which point of time it refers to, no matter in which timezone the event happens. In such case, the attribute is a dictionary of a single key:
 

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -96,12 +96,12 @@ tokenDefinition = {
         attributeId: attribute,
         category: {
             name: "Cat",
-	    syntax: IA5String,
+	    syntax: "IA5String",
 	    single: "true",
         },
         startTime: {
             name: "Event Start Time",
-	    syntax: BinaryTime
+	    syntax: "BinaryTime",
         },
         ...
     },
@@ -167,7 +167,7 @@ instance = {
 }
 ```
 
-However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys. The time as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information like [examplified](../examples/ticket/js/generalized-time-test.html).
+However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys. The time as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information like [exemplified](../examples/ticket/js/generalized-time-test.html).
 
 ```
 instance = {
@@ -180,7 +180,7 @@ instance = {
 }
 ```
 
-If a developer intends to find out if an attribute is of BinaryTime or GeneralizedTime, he can look up the definition.
+If a developer intends to find out if an attribute is of `BinaryTime` or `GeneralizedTime`, he can look up the definition (search for `BinaryTime` in the begining of this document for an example).
 
 The value of `someDate.locale` would be what you expect normally. `someDate.venue` is the date you would use for displaying a venue-specific time, eg. a soccer game match time, that should always be displayed in the venue's timezone. to display such a time, use `someDate.venue` and print it in your locale. The value has already been corrected for it:
 

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -68,7 +68,7 @@ token = {
 
 Where attributes like `votingRights` are defined in Tokenscript.
 
-For a non-fungible token, like a ticket to a venue:
+For a non-fungible token, like a ticket to an event:
 
 ```
 token = {
@@ -160,7 +160,7 @@ Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas 
 ```
 instance = {
     section: "22",
-    meetingStarts: {
+    startTime: {
         date: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
     }
     ...
@@ -169,12 +169,12 @@ instance = {
 
 (Key name `date` is chosen because that's how JavaScript calls time).
 
-However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys: `date` as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information like [exemplified](../examples/ticket/js/generalized-time-test.html).
+However, in the case the time relevent to the timezone is important, the token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime). Take a FIFA football match ticket as an example, `matchTime` attribute is a dictionary of two keys: `date` as a Date object, not containing timezone, and the raw value for GeneralizedTime which has the timezone in it.
 
 ```
 instance = {
     section: "22",
-    matchStarts: {
+    matchTime: {
         generalizedTime: "19851106210627-0500",
         date: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
     }
@@ -184,11 +184,7 @@ instance = {
 
 If a developer intends to find out if an attribute is of `BinaryTime` or `GeneralizedTime`, he can look up the definition (search for `BinaryTime` in the begining of this document for an example).
 
-The value of `someDate.locale` would be what you expect normally. `someDate.venue` is the date you would use for displaying a venue-specific time, eg. a soccer game match time, that should always be displayed in the venue's timezone. to display such a time, use `someDate.venue` and print it in your locale. The value has already been corrected for it:
-
-```
-return instance.someDate.venue.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})
-```
+The value of `matchTime.date` would be a normal `Date` object, the time the match starts. As every `Date` object, it doesn't contain the timezone information. But if you want to display a venue-specific time, eg. a soccer game match time at the venue, you need to extract that information from the `generalizedTime` string, like shown in the [example](../examples/ticket/js/generalized-time-test.html).
 
 ## B. Callback
 

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -161,20 +161,22 @@ Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas 
 instance = {
     section: "22",
     meetingStarts: {
-        time: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
+        date: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
     }
     ...
 }
 ```
 
-However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys. The time as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information like [exemplified](../examples/ticket/js/generalized-time-test.html).
+(Key name `date` is chosen because that's how JavaScript calls time).
+
+However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys: `date` as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information like [exemplified](../examples/ticket/js/generalized-time-test.html).
 
 ```
 instance = {
     section: "22",
     matchStarts: {
-        value: "19851106210627-0500",
-        time: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
+        generalizedTime: "19851106210627-0500",
+        date: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
     }
     ...
 }

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -167,7 +167,7 @@ instance = {
 }
 ```
 
-However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys. The time as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information if needed.
+However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys. The time as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information like [examplified](../examples/ticket/js/generalized-time-test.html).
 
 ```
 instance = {

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -161,13 +161,13 @@ Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas 
 instance = {
     section: "22",
     startTime: {
-        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆(1985, 10, 6, 21, 22, 27, 0)
+        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆("1985-11-07T02:06:27")
     }
     ...
 }
 ```
 
-Date object is represented with the code how it would have been created in Sydney (AEDT) time.
+Date object is represented by the code with which it would have been created. The key is `date` to inherit the misnaming by JavaScript.
 
 However, in the case the time relevent to the timezone is important, the token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime). Take a FIFA football match ticket as an example, `matchTime` attribute is a dictionary of two keys: `date` as a Date object, not containing timezone, and the raw value for GeneralizedTime which has the timezone in it.
 
@@ -176,7 +176,7 @@ instance = {
     section: "22",
     matchTime: {
         generalizedTime: "19851106210627-0500",
-        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆(1985, 10, 6, 21, 22, 27, 0)
+        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆("1985-11-07T02:06:27")
     }
     ...
 }

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -161,7 +161,7 @@ Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas 
 instance = {
     section: "22",
     startTime: {
-        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆("1985-11-07T02:06:27")
+        date: new Date("1985-11-07T02:06:27")
     }
     ...
 }
@@ -176,7 +176,7 @@ instance = {
     section: "22",
     matchTime: {
         generalizedTime: "19851106210627-0500",
-        date: 𝑛𝑒𝑤 𝑫𝒂𝒕𝒆("1985-11-07T02:06:27")
+        date: new Date("1985-11-07T02:06:27")
     }
     ...
 }

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -99,9 +99,9 @@ tokenDefinition = {
 	    syntax: IA5String,
 	    single: "true",
         },
-        countryA: {
-            name: "County A",
-	    syntax: IA5String
+        startTime: {
+            name: "Event Start Time",
+	    syntax: BinaryTime
         },
         ...
     },
@@ -134,7 +134,7 @@ The other elements in a `tokenDefinition`, like `name` and `symbol`, refer to th
 
 If you compare [spawnable-contract/schema1/token-plain-javascript.xsl](../spawnable-contract/schema1/token-plain-javascript.xsl) and [blockchain-tickets/schema1/token-plain-javascript.xsl](../blockchain-tickets/schema1/token-plain-javascript.xsl), you can see what needs to be done for changing the layout (aside from some boilerplate).
 
-### attribute-value? not always
+### attribute-value pair? not always
 
 In the previous example, observe that not every attribute of a token is of a primitive type.
 
@@ -151,32 +151,36 @@ token = {
 }
 ```
 
-There are two attributes that are not of a primivite type: `locked`, which represents the balance committed somehow (typically, to a state channel), and `expiry` which is how much the balance will disappear at certain date, typically used as an incentive for users to spend, the opposite incentive of Bitcoin. The two might give you the impression that only "dynamic" attributes are complex. That's not the case.
+There are two attributes that are not of a primivite type: `locked`, which represents the balance committed somehow (typically, to a state channel), and `expiry` which is how much the balance will disappear at certain date, typically used as an incentive for users to spend, the opposite incentive of Bitcoin.
 
-Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas efficiency, which is just binary encoded UnixTime. When used as the time of an event, there is no ambiguity which point of time it refers to, no matter in which timezone the event happens. In such case, the value is in a dictionary consisting of exactly one key: 'local', which in turn contains a JavaScript Date object. (The key `local` has no meaning here because the API does not actually supply a string; it supplies a JavaScript Date object. It's only to prevent developers to wonder if it would localise correctly.)
+What form of value do we have for each attribute is a result of the attrubte-type found in `tokenDefinition`.
+
+Take time as an example. Typically, blockchain uses `BinaryTime` syntax for gas efficiency, which is just binary encoded UnixTime. When used as the time of an event, there is no ambiguity which point of time it refers to, no matter in which timezone the event happens. In such case, the attribute is a dictionary of a single key:
 
 ```
 instance = {
     section: "22",
     meetingStarts: {
-        local: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
+        time: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
     }
     ...
 }
 ```
 
-However, sometimes the data has to contain timezone information. In the case of FIFA ticket (tokenised), the time displayed should be relevent to the timezone of the match's venue and not fluctuate based on user's local timezone. therefore UnixTime isn't sufficient on its own. In such case, a `GeneralizedTime` is used specifically to cointain the time zone information. When that is used,
+However, sometimes - tokenised FIFA ticket or airline ticket - the time should be relevant to the timezone. The token designer would have supplied a [GeneralizedTime](https://en.wikipedia.org/wiki/GeneralizedTime) as the value of such an attribute. The attribute is a dictionary of two keys. The time as a Date object and the raw value for GeneralizedTime, which can be used to extract timezone information if needed.
 
 ```
 instance = {
     section: "22",
     matchStarts: {
-        remote: Wed Jan 30 2019 14:16:54 GMT+1100 (AEDT),
-        local: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
+        value: "19851106210627-0500",
+        time: Wed Jan 30 2019 17:16:54 GMT+1100 (AEDT)
     }
     ...
 }
 ```
+
+If a developer intends to find out if an attribute is of BinaryTime or GeneralizedTime, he can look up the definition.
 
 The value of `someDate.locale` would be what you expect normally. `someDate.venue` is the date you would use for displaying a venue-specific time, eg. a soccer game match time, that should always be displayed in the venue's timezone. to display such a time, use `someDate.venue` and print it in your locale. The value has already been corrected for it:
 

--- a/examples/ticket/js/generalized-time-test.html
+++ b/examples/ticket/js/generalized-time-test.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+ "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+  <head>
+    <title>Generalized Time testing page</title>
+    <script type="text/javascript" src="generalized-time.js">
+    </script>
+  </head>
+  <body>
+    <h1>You will see a few alerts</h1>
+    <script type="text/javascript">
+	// value taken from the example on wikipedia
+        // https://en.wikipedia.org/wiki/GeneralizedTime
+	gt = new GeneralizedTime("19851106210627.3-0500")
+	alert("Hour: " + gt.getHours());
+	alert("Timezone: " + gt.getTimeZone());
+    </script>
+  </body>
+</html>

--- a/examples/ticket/js/generalized-time.js
+++ b/examples/ticket/js/generalized-time.js
@@ -1,0 +1,94 @@
+;(function() {
+'use strict'
+
+    function pad2(num) {
+      if (num < 10) return '0' + num
+      return '' + num
+    }
+
+    function pad4(num) {
+      if (num < 10) return '000' + num
+      if (num < 100) return '00' + num
+      if (num < 1000) return '0' + num
+      return '' + num
+    }
+
+    function GeneralizedTime(generalizedTime) {
+	this.rawData = generalizedTime;
+    }
+
+    GeneralizedTime.prototype.getYear = function () {
+	return parseInt(this.rawData.substring(0, 4), 10);
+    }
+    
+    GeneralizedTime.prototype.getMonth = function () {
+	return parseInt(this.rawData.substring(4, 6), 10) - 1;
+    }
+
+    GeneralizedTime.prototype.getDay = function () {
+	return parseInt(this.rawData.substring(6, 8), 10)
+    },
+
+    GeneralizedTime.prototype.getHours = function () {
+	return parseInt(this.rawData.substring(8, 10), 10)
+    },
+    
+    GeneralizedTime.prototype.getMinutes = function () {
+	var minutes = parseInt(this.rawData.substring(10, 12), 10)
+	if (minutes) return minutes
+	return 0
+    },
+    
+    GeneralizedTime.prototype.getSeconds = function () {
+	var seconds = parseInt(this.rawData.substring(12, 14), 10)
+	if (seconds) return seconds
+	return 0
+    },
+    
+    GeneralizedTime.prototype.getMilliseconds = function () {
+	var startIdx
+	if (time.indexOf('.') !== -1) {
+	  startIdx = this.rawData.indexOf('.') + 1
+	} else if (time.indexOf(',') !== -1) {
+	  startIdx = this.rawData.indexOf(',') + 1
+	} else {
+	  return 0
+	}
+
+	var stopIdx = time.length - 1
+	var fraction = '0' + '.' + time.substring(startIdx, stopIdx)
+	var ms = parseFloat(fraction) * 1000
+	return ms
+    },
+    
+    GeneralizedTime.prototype.getTimeZone = function () {
+	let time = this.rawData;
+	var length = time.length
+	var symbolIdx
+	if (time.charAt(length - 1 ) === 'Z') return 0
+	if (time.indexOf('+') !== -1) {
+	  symbolIdx = time.indexOf('+')
+	} else if (time.indexOf('-') !== -1) {
+	  symbolIdx = time.indexOf('-')
+	} else {
+	  return NaN
+	}
+
+	var minutes = time.substring(symbolIdx + 2)
+	var hours = time.substring(symbolIdx + 1, symbolIdx + 2)
+	var one = (time.charAt(symbolIdx) === '+') ? 1 : -1
+
+	var intHr = one * parseInt(hours, 10) * 60 * 60 * 1000
+	var intMin = one * parseInt(minutes, 10) * 60 * 1000
+	var ms = minutes ? intHr + intMin : intHr
+	return ms
+      }
+
+    if (typeof exports === 'object') {
+      module.exports = GeneralizedTime
+    } else if (typeof define === 'function' && define.amd) {
+      define(GeneralizedTime)
+    } else {
+      window.GeneralizedTime = GeneralizedTime
+    }
+}())


### PR DESCRIPTION
@hboon @JamesSmartCell notice the change in Date. I didn't change the buggy design which causes a zoned date-time to drift with the user's device, which is:

1. If the user has a local time of 11 pm Sydney and the FIFA match is at Mosco time of 5 pm, the user's mobile phone displays the time of the match at 5 pm, which is internally stored as 5pm Sydney (6am UTC+0) since Javascript internally try to keep time unambiguous.
2. The user takes off.
3. The user lands in Mosco. The mobile phone updates the time and the ticket says the FIFA match starts at 9 am (6 am UTC+3).

@hboon is of the opinion that this can be amended by having react framework to send an update to refresh the FIFA start time as 5 pm Mosco (5pm UTC+3). But that means:

- When timezone changes, the react framework need to send a diff to indicate that the data has changed despite nothing on the blockchain or from any web-api has changed.
- If the developer isn't using react, the user can get the right time by re-rendering the token (maybe triggered by switching to dapp and back to wallet).

These two are confusing behaviours. @hboon rationalise that these are needed to make javascript coders not having to think about time/date. I actually disagree since the time in the venue is incorrect.