### PR TITLE
Tweak JavaScript in example to use TokenScript dataChanged() callback and render BinaryTime

### DIFF
--- a/examples/ticket/cards/enter.en.shtml
+++ b/examples/ticket/cards/enter.en.shtml
@@ -1,5 +1,4 @@
 <script type="text/javascript">
-<![CDATA[
         function startup() {
             // 1. call API to fetch challenge
             document.getElementById('msg').innerHTML = "Loading challenge ..."
@@ -21,7 +20,6 @@
 
     // this is better but we don't know how to make it work:
     // window.addEventListener('confirm', onConfirm, false);
-]]>
 </script>
 
 <h3>Welcome to Craig Wright's house!</h3>

--- a/examples/ticket/cards/token.en.shtml
+++ b/examples/ticket/cards/token.en.shtml
@@ -1,5 +1,4 @@
 <script type="text/javascript">
-<![CDATA[
     class Token {
     constructor(tokenInstance) {
     this.props = tokenInstance
@@ -51,7 +50,6 @@
         const domHtml = new Token(currentTokenInstance).render()
         document.getElementById('root').innerHTML = domHtml
       }
-]]>
 </script>
     
 <div id="root"></div>

--- a/examples/ticket/cards/token.en.shtml
+++ b/examples/ticket/cards/token.en.shtml
@@ -5,17 +5,22 @@
     this.props = tokenInstance
     }
     
-    //TODO: Replace with updated time
-    formatTime(d) {
-    return d.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})
+    formatBinaryTimeToDate(d) {
+      return d.toLocaleDateString()
+    }
+    formatBinaryTimeToTime(d) {
+      return d.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})
     }
     
     render() {
       let time;
+      let date;
       if (this.props.time == null) {
           time = ""
+          date = ""
       } else {
-          time = this.formatTime(this.props.time.venue)
+          time = this.formatBinaryTimeToTime(this.props.time.date)
+          date = this.props.time == null ? "": this.formatBinaryTimeToDate(this.props.time.date)
       }
       const result = `<div>
         <div>
@@ -29,7 +34,7 @@
          </div>
         <div>
           <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADkAAAA5CAYAAACMGIOFAAAABGdBTUEAALGPC/xhBQAABw9JREFUaAXtWt1vFFUUP3d224JVqHyVXTSCjzYVBFMx/eTJJ1tQ+yA+iBLEIDGa+CBP4h+gMcYXYgR8sDxUacs/YD8DkgjWBB+lpHa3hbZQpNDdzs71nNmZ3Xvv3PlYk+IWd5LNnM/fPWdm7p1zzyyDEo8DYzMvW2buFAB/Gl17qtuSH/YylguD6b58c2t2yTwLHJqBwVj1mvih3qYt06F+nMeyw6mv0e4gAJs04rGjfc31F8P8RL0hMmE055xZOfNHDryRA9Th79jyaPpwmB/pM0vml+j/Cvo+Tmfio/gRPo2TH4832uNjHFF8XZuSknz9l/ltnEPSdaazBdAk8n40RiXZqbyfn4pP41McfvY6eUlJWjwb94Bw8Mo8RrZAtVN5vZcGXxuH3ts7cPc1Xp1ZuNVg5HLrRR/D4NfPNydviDIdvX8k3SHKGRi3+1rrx0WZjt4/dnMXWLk6UdffmhgUeR29/2J6O5iwXdRZsdhCzfrN13obWNaV21ezc/TWE8xa/iI7l3obF4ZqfESkwwLjJAo+l4QaxrKsn0UxY3wQ+X2iTEfjPPsKOG9XdEzhvWzWOoSxfiYpLAswj2znUOosxKo+udCy+W+D7h5Y2VFcDI7g814tOZQ5Y+Ejpgsxnwd/D/MaofyMzPz0Cbx7z+uMV72Mw87s3PSnBuP81VWfTGACvBPnJG8UbRiwCW6ws6IsxmFQ5H1pw567BbVhwUSBCSBinJ3JGUyazwHmBRXFhc+rtFZwxg7h1HumYIT5xT3zkMHEhdaE5Fh0CKb+rV9fe+L7YGS9tq8tMYQa+hWOzuFUBzKFJCm/kt6ThoUuysFwWVREehZLHUmh8pKyyOjwdXEUPbxUSUnG6hJphFgSYfBd+KfI+9GccclO5f38VHzG4IETh5+LR15SkvSCxTn7ERbKpo3E4PfH2NpvPKgagQHGCfSbzavYbJ7XGCoiGx/HcfxM4Oxj8UWvmGvZkpIkhIH25KnamthTRrzqhd2tyT09rXW3tciKsL8tcblmU3yHYbAX6Uy8YqJlCZ/GiRnxXTQuja81DBDaFU+AXqs6t7d+BhUz/Vqtv7C3Ycs91P7qb6HXnGT2kxNaHuq9AUq+k35A5SyvJFnOd6eU2Cp3spSrVc62kVfXruH0c1gTvotNqE1SQgxMfBwuV7UkvtM1tA6O3HnyPn9wnIP1LAd8lTsHVTL0oqf3oO411I0NLOrv4H6xCWslOU4Os4yx0wNtiT9cvKCz7Oxj2T00vSPDLXyv8VqlOEOR3ec5jB21nej+gQhxkvP4lZHUINo4W7liZUcUJg73YPENtNvjvCYK7tShQ5tjBYFCYDH5PsbV2Nu+9bqi8rCR5mTGsDrtBD3ukgBbhvIxPnqzoZigrCtweAFsu4KgQHjwChqb4LX5uGSpjouUZIzBpM5ZljGPzZoqwL6qUwLKxgLHzLydILJJL55qES2uiMXA+eZEH86mMzilis+bPOIUNX1lEQBVRjgJj1NRreqIJznpnQpKMnHwpiShy2AcFA/F5YqCzqxzaEoKHCf04EBbcp/OiRpecba8QdLFanI/vbRhCv0kHNGG+iy5O+mEKCOadhNBxTYudMzuseYyMdHX5FXz1KASZS6N+0lcA+SmWKSFxwVwgD3ghSXTNVTOTiI3FHEo61y4v0INQwwizckQjLJX/y+SLOlxpTlpxMyN4q0zWLUZdU5aBi4XzkEtjKhzUv0sYOXic35z0sUXz5HuJC0AXcNTp8FaXrCy1nXxZ2aWJruGU5P0SU8EdumuodTRzGxqwTT5hOSHPHa675DetRXPhEe4hC/6EU1xUDwUl+jjR0dK8rWx9AGsMN6xKzE90rb8N0tZ+ealmXpccqk9skbW5DnEXEt6slP1Dp7+6xUmR/FQXKqfjo+UZI4DfXANOeyPspLN0jJsxUopZErweN5OckXGi6daRIsrYjFQYxkX8NW9qA6i8D0KDztbtlzDgt5pQqlah0e9bedVe/BkE7aYj0uW6riQq5x3oSIYdyFN+IgE7kLUAajoxl1Ix30I3oWoxTnh0Gd63IWMB+1CetvCi3PCKqniIYdyP3QVT6Q5We6JhcVXSTLsCq0WfaSFh5KptD8AKu2PwMe60v4IvDzwUNsfuLdIBbU/MFTpm6YQ+hJW2L7tD8IVbIvkSrY/3ro0t26RZ6X2x3+x1apl1fM/7N14t5h1kdIVA5FXV4JxgD3gYfudSvujeBNWjKpUPCt2aR8ycOVOPuQLvmLDMVxyF7B3s84dAf/CsoDtod9cfrWdsY+/C/8HVfy/LmN347j8X8FmUoebjG3Aod3lV9sZc1GPq/ifIfhWlT5KPP4N9JQx0JLsoS9Ej1Jibi64qp7ub912rlCsdI2mDuKH3yN4u3eLc9R1WDVnnIMY61W6g5Qgxf0P/UFw0L/BhyIAAAAASUVORK5CYII=" class="data-icon"/>
-          <span class="tbml-date">${this.props.time == null ? "": this.props.time.venue.toLocaleDateString()}</span>
+          <span class="tbml-date">${date}</span>
         </div>
         <div>
           <span class="tbml-time">${time}</span>  (<span>${this.props.locality}</span>)
@@ -41,11 +46,11 @@
     </script>
     
     <script>
-    function refresh() {
-    const currentTokenInstance = web3.token
-    const domHtml = new Token(currentTokenInstance).render()
-    document.getElementById('root').innerHTML = domHtml
-    }
+      web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
+        const currentTokenInstance = web3.tokens.data.currentInstance
+        const domHtml = new Token(currentTokenInstance).render()
+        document.getElementById('root').innerHTML = domHtml
+      }
 ]]>
 </script>
     


### PR DESCRIPTION
Changes:

1. Introduce JavaScript functions in the example to format BinaryTime into date and time, separately. (it reads from `this.props.time.date` instead of `this.props.time.venue`).
2. Call `web3.tokens.dataChanged()` instead of `refresh()`

---

@JamesSmartCell: the Android TokenScript client will need to make the following changes:

1. Generally for datetime(s), instead of generating `GeneralizedTime` as a dictionary with the keys `venue` and `locale`, you'll have to generate them with the keys `generalizedTime` and `date` [1]:


```
time: {
    generalizedTime: "19851106210627-0500",
    date: new Date("1985-11-07T02:06:27")
}
```

For our door token example, since the `time` attribute is BinaryTime, we omit the `generalizedTime` key and generate it like this:

```
time: {
    date: new Date("1985-11-07T02:06:27")
}
```

Note that the string `"1985-11-07T02:06:27"` passed to the JavaScript Date constructor in both cases should be UTC+0.

2. Instead of calling the JavaScript function `refresh()` in the mobile app, call `web3.tokens.dataChanged(oldTokens, updatedTokens)` passing in 2 arguments, the 1st argument being the value of `web3.tokens.data` before the change and the 2nd argument being the new value of `web3.tokens.data`, by the time this JavaScript function is called, `web3.tokens.data` should already been changed.

[1] https://github.com/AlphaWallet/TokenScript/blob/master/doc/javascript_api.md Search for `GeneralizedTime`