### PR TITLE
Tweak Javascript in example to display as GeneralizedTime instead

### DIFF
--- a/examples/ticket/cards/token.en.shtml
+++ b/examples/ticket/cards/token.en.shtml
@@ -1,4 +1,99 @@
 <script type="text/javascript">
+      ;(function() {
+'use strict'
+
+    function pad2(num) {
+      if (num &lt; 10) return '0' + num
+      return '' + num
+    }
+
+    function pad4(num) {
+      if (num &lt; 10) return '000' + num
+      if (num &lt; 100) return '00' + num
+      if (num &lt; 1000) return '0' + num
+      return '' + num
+    }
+
+    function GeneralizedTime(generalizedTime) {
+	this.rawData = generalizedTime;
+    }
+
+    GeneralizedTime.prototype.getYear = function () {
+	return parseInt(this.rawData.substring(0, 4), 10);
+    }
+
+    GeneralizedTime.prototype.getMonth = function () {
+	return parseInt(this.rawData.substring(4, 6), 10) - 1;
+    }
+
+    GeneralizedTime.prototype.getDay = function () {
+	return parseInt(this.rawData.substring(6, 8), 10)
+    },
+
+    GeneralizedTime.prototype.getHours = function () {
+	return parseInt(this.rawData.substring(8, 10), 10)
+    },
+
+    GeneralizedTime.prototype.getMinutes = function () {
+	var minutes = parseInt(this.rawData.substring(10, 12), 10)
+	if (minutes) return minutes
+	return 0
+    },
+
+    GeneralizedTime.prototype.getSeconds = function () {
+	var seconds = parseInt(this.rawData.substring(12, 14), 10)
+	if (seconds) return seconds
+	return 0
+    },
+
+    GeneralizedTime.prototype.getMilliseconds = function () {
+	var startIdx
+	if (time.indexOf('.') !== -1) {
+	  startIdx = this.rawData.indexOf('.') + 1
+	} else if (time.indexOf(',') !== -1) {
+	  startIdx = this.rawData.indexOf(',') + 1
+	} else {
+	  return 0
+	}
+
+	var stopIdx = time.length - 1
+	var fraction = '0' + '.' + time.substring(startIdx, stopIdx)
+	var ms = parseFloat(fraction) * 1000
+	return ms
+    },
+
+    GeneralizedTime.prototype.getTimeZone = function () {
+	let time = this.rawData;
+	var length = time.length
+	var symbolIdx
+	if (time.charAt(length - 1 ) === 'Z') return 0
+	if (time.indexOf('+') !== -1) {
+	  symbolIdx = time.indexOf('+')
+	} else if (time.indexOf('-') !== -1) {
+	  symbolIdx = time.indexOf('-')
+	} else {
+	  return NaN
+	}
+
+	var minutes = time.substring(symbolIdx + 2)
+	var hours = time.substring(symbolIdx + 1, symbolIdx + 2)
+	var one = (time.charAt(symbolIdx) === '+') ? 1 : -1
+
+	var intHr = one * parseInt(hours, 10) * 60 * 60 * 1000
+	var intMin = one * parseInt(minutes, 10) * 60 * 1000
+	var ms = minutes ? intHr + intMin : intHr
+	return ms
+      }
+
+    if (typeof exports === 'object') {
+      module.exports = GeneralizedTime
+    } else if (typeof define === 'function' &amp;&amp; define.amd) {
+      define(GeneralizedTime)
+    } else {
+      window.GeneralizedTime = GeneralizedTime
+    }
+}())
+
     class Token {
     constructor(tokenInstance) {
     this.props = tokenInstance
@@ -10,6 +105,14 @@
     formatBinaryTimeToTime(d) {
       return d.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})
     }
+    formatGeneralizedTimeToDate(str) {
+      const d = new GeneralizedTime(str)
+      return new Date(d.getYear(), d.getMonth(), d.getDay(), d.getHours(), d.getMinutes(), d.getSeconds()).toLocaleDateString()
+    }
+    formatGeneralizedTimeToTime(str) {
+      const d = new GeneralizedTime(str)
+      return new Date(d.getYear(), d.getMonth(), d.getDay(), d.getHours(), d.getMinutes(), d.getSeconds()).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})
+    }
     
     render() {
       let time;
@@ -18,8 +121,8 @@
           time = ""
           date = ""
       } else {
-          time = this.formatBinaryTimeToTime(this.props.time.date)
-          date = this.props.time == null ? "": this.formatBinaryTimeToDate(this.props.time.date)
+          time = this.formatGeneralizedTimeToTime(this.props.time.generalizedTime)
+          date = this.props.time == null ? "": this.formatGeneralizedTimeToDate(this.props.time.generalizedTime)
       }
       const result = `<div>
         <div>


### PR DESCRIPTION
@JamesSmartCell if the `time` attribute is already generated as a dictionary with `date` and `generalizedTime` key-value pairs, this should just work and display as 5pm.

You can see examples of why CDATAs are useful here. This PR uses code that includes < and &. In order to work without CDATAs, I modified them to be entities like `&lt;` and `&amp;`. Let's just leave it like this for the moment and we can revisit why it doesn't work when we have the time. (but useful to know in case this comes up during the workshop)