### PR TITLE
Tweak Javascript/HTML in example sign challenge as personal message and close screen after sending response successfully

### DIFF
--- a/examples/ticket/cards/enter.en.shtml
+++ b/examples/ticket/cards/enter.en.shtml
@@ -1,25 +1,38 @@
 <script type="text/javascript">
-        function startup() {
-            // 1. call API to fetch challenge
-            document.getElementById('msg').innerHTML = "Loading challenge ..."
-            const Http = new XMLHttpRequest();
-            const url = 'http://stormbird.duckdns.org:8080/api/getChallenge';
-            Http.open("GET", url);
-            Http.send();
-            Http.onreadystatechange = (e) => {
-                document.getElementById('msg').innerHTML = 'Challenge: ' + Http.responseText
-            }
-        }
+window.onload = function startup() {
+	// 1. call API to fetch challenge
+	fetch('http://stormbird.duckdns.org:8080/api/getChallenge')
+	  .then(function(response) {
+		return response.text()
+	  })
+	  .then(function(response) {
+		document.getElementById('msg').innerHTML = 'Challenge: &amp;' + response
+		window.challenge = response
+	  })
+	}
 
-    function onConfirm(signature) {
-        document.getElementById('msg').innerHTML = 'Pressed confirm' //TODO: Handle signature check
-    }
-
-    window.onload = startup;
-    window.onconfirm = onConfirm;
-
-    // this is better but we don't know how to make it work:
-    // window.addEventListener('confirm', onConfirm, false);
+window.onConfirm = function onConfirm(signature) {
+	if (window.challenge === undefined || window.challenge.length == 0) return
+	const challenge = window.challenge
+	document.getElementById('msg').innerHTML = 'Opening...'
+	// 2. sign challenge to generate response
+	web3.personal.sign({data: challenge}, function(error, value) {
+		document.getElementById('msg').innerHTML = 'Response: ' + value + '::' + error
+		// 3. open door
+		fetch(`http://stormbird.duckdns.org:8080/api/checkSignature?contract=0x0C8D487DD27D7c4A027D9f92915659139e0b2FF2&amp;challenge=${challenge}&amp;sig=${value}`)
+		  .then(function(response) {
+			return response.text()
+		  })
+		  .then(function(response) {
+			if (response == "pass") {
+			  window.close()
+			} else {
+			  document.getElementById('msg').innerHTML = 'Failed with: ' + response
+			}
+		  })
+	})
+	window.challenge = '';
+}
 </script>
 
 <h3>Welcome to Craig Wright's house!</h3>

--- a/examples/ticket/cards/enter.en.shtml
+++ b/examples/ticket/cards/enter.en.shtml
@@ -1,37 +1,38 @@
 <script type="text/javascript">
 window.onload = function startup() {
-	// 1. call API to fetch challenge
-	fetch('http://stormbird.duckdns.org:8080/api/getChallenge')
-	  .then(function(response) {
-		return response.text()
-	  })
-	  .then(function(response) {
-		document.getElementById('msg').innerHTML = 'Challenge: &amp;' + response
-		window.challenge = response
-	  })
-	}
+    // 1. call API to fetch challenge
+    fetch('http://stormbird.duckdns.org:8080/api/getChallenge')
+        .then(function (response) {
+            return response.text()
+        })
+        .then(function (response) {
+            document.getElementById('msg').innerHTML = 'Challenge: ' + response
+            window.challenge = response
+        })
+}
 
 window.onConfirm = function onConfirm(signature) {
-	if (window.challenge === undefined || window.challenge.length == 0) return
-	const challenge = window.challenge
-	document.getElementById('msg').innerHTML = 'Opening...'
-	// 2. sign challenge to generate response
-	web3.personal.sign({data: challenge}, function(error, value) {
-		document.getElementById('msg').innerHTML = 'Response: ' + value + '::' + error
-		// 3. open door
-		fetch(`http://stormbird.duckdns.org:8080/api/checkSignature?contract=0x0C8D487DD27D7c4A027D9f92915659139e0b2FF2&amp;challenge=${challenge}&amp;sig=${value}`)
-		  .then(function(response) {
-			return response.text()
-		  })
-		  .then(function(response) {
-			if (response == "pass") {
-			  window.close()
-			} else {
-			  document.getElementById('msg').innerHTML = 'Failed with: ' + response
-			}
-		  })
-	})
-	window.challenge = '';
+    if (window.challenge === undefined || window.challenge.length == 0) return
+    const challenge = window.challenge
+    document.getElementById('msg').innerHTML = 'Wait for signature...'
+    // 2. sign challenge to generate response
+    web3.personal.sign({ data: challenge }, function (error, value) {
+        document.getElementById('msg').innerHTML = 'Verifying credentials ...'
+        // 3. open door
+        fetch(`http://stormbird.duckdns.org:8080/api/checkSignature?contract=0x0C8D487DD27D7c4A027D9f92915659139e0b2FF2&amp;challenge=${challenge}&amp;sig=${value}`)
+            .then(function (response) {
+                return response.text()
+            })
+            .then(function (response) {
+                if (response == "pass") {
+                    document.getElementById('msg').innerHTML = 'Entrance granted!'
+                    window.close()
+                } else {
+                    document.getElementById('msg').innerHTML = 'Failed with: ' + response
+                }
+            })
+    })
+    window.challenge = '';
 }
 </script>
 


### PR DESCRIPTION
@JamesSmartCell required change in the TokenScript client for Android.

Originally, you'd have something like this:

```
        return """
               const addressHex = "\(address.description.lowercased())"
               const rpcURL = "\(server.rpcURL.absoluteString)"
               const chainID = "\(server.chainID)"

               function executeCallback (id, error, value) {
                   AlphaWallet.executeCallback(id, error, value)
               }

               AlphaWallet.init(rpcURL, {
                   getAccounts: function (cb) { cb(null, [addressHex]) },
                   processTransaction: function (tx, cb){
                       console.log('signing a transaction', tx)
                       const { id = 8888 } = tx
                       AlphaWallet.addCallback(id, cb)
                       webkit.messageHandlers.signTransaction.postMessage({"name": "signTransaction", "object":     tx, id: id})
                   },
                   signMessage: function (msgParams, cb) {
                       const { data } = msgParams
                       const { id = 8888 } = msgParams
                       console.log("signing a message", msgParams)
                       AlphaWallet.addCallback(id, cb)
                       webkit.messageHandlers.signMessage.postMessage({"name": "signMessage", "object": { data }, id:    id} )
                   },
                   signPersonalMessage: function (msgParams, cb) {
                       const { data } = msgParams
                       const { id = 8888 } = msgParams
                       console.log("signing a personal message", msgParams)
                       AlphaWallet.addCallback(id, cb)
                       webkit.messageHandlers.signPersonalMessage.postMessage({"name": "signPersonalMessage", "object":  { data }, id: id})
                   },
                   signTypedMessage: function (msgParams, cb) {
                       const { data } = msgParams
                       const { id = 8888 } = msgParams
                       console.log("signing a typed message", msgParams)
                       AlphaWallet.addCallback(id, cb)
                       webkit.messageHandlers.signTypedMessage.postMessage({"name": "signTypedMessage", "object":     { data }, id: id})
                   }
               }, {
                   address: addressHex,
                   networkVersion: chainID
               })

               web3.setProvider = function () {
                   console.debug('AlphaWallet Wallet - overrode web3.setProvider')
               }

               web3.eth.defaultAccount = addressHex

               web3.version.getNetwork = function(cb) {
                   cb(null, chainID)
               }

              web3.eth.getCoinbase = function(cb) {
               return cb(null, addressHex)
             }
             """
```

Keep doing that for the dapp browser, but for TokenScript rendering, do this instead:

```
        return """
               window.web3CallBacks = {}

               function executeCallback (id, error, value) {
                   window.web3CallBacks[id](id, error, value)
                   delete window.web3CallBacks[id]
               }

               web3 = {
                 personal: {
                   sign: function (msgParams, cb) {
                     const { data } = msgParams
                     const { id = 8888 } = msgParams
                     window.web3CallBacks[id] = cb
                     webkit.messageHandlers.signPersonalMessage.postMessage({"name": "signPersonalMessage", "object":  { data }, id: id})
                   }
                 }
               }
               """
```

I'm assuming we use `web3.personal.sign`. We can use something else if it's more appropriate.