### PR TITLE
Remove standard fonts from shared styles in example

### DIFF
--- a/examples/ticket/cards/shared.css
+++ b/examples/ticket/cards/shared.css
@@ -1,24 +1,3 @@
-
-@font-face {
-    font-family: 'SourceSansPro-Light';
-    src: local('SourceSansPro-Light'),url('SourceSansPro-Light.otf') format('opentype');
-    font-weight: lighter;
-    }
-    @font-face {
-    font-family: 'SourceSansPro-Regular';
-    src: local('SourceSansPro-Regular'),url('SourceSansPro-Regular.otf') format('opentype');
-    font-weight: normal;
-    }
-    @font-face {
-    font-family: 'SourceSansPro-Semibold';
-    src: local('SourceSansPro-Semibold'),url('SourceSansPro-Semibold.otf') format('opentype');
-    font-weight: bold;
-    }
-    @font-face {
-    font-family: 'SourceSansPro-Bold';
-    src: local('SourceSansPro-Bold'),url('SourceSansPro-Bold.otf') format('opentype');
-    font-weight: boldedr;
-    }
     .tbml-count {
     font-family: "SourceSansPro-Bold";
     font-weight: bolder;


### PR DESCRIPTION
Remove the standard fonts from shared styles, which should be injected directly by the app.

Implementation-wise, instead of doing:

```
return """
       \(sharedStyles)
       \(sanitizedHtml)
       """
```

do:

```
return """
       \(standardFontStyles)
       \(sharedStyles)
       \(sanitizedHtml)
       """
```

The iOS version injects something like this (for each `@font-face`) as standardFontStyles:

```
<style type="text/css">
@font-face {
font-family: 'SourceSansPro';
src: url('\(Constants.tokenScriptUrlSchemeForResources)SourceSansPro-Light.otf') format('opentype');
font-weight: lighter;
}
...
</style>
```

This is because the path to access the fonts should/would not be exposed to the TokenScript authors. In the future, we might consider renaming the font family to something along the lines of "Standard" or "System".