### PR TITLE
fix make error by introducing CDATA

### DIFF
--- a/examples/ticket/Makefile
+++ b/examples/ticket/Makefile
@@ -2,8 +2,11 @@
 	# XML Canonicalization
 	xmlstarlet c14n $^  > $@.xml
 	# Validating -- might take a long time to download xsd files from w3.org
+	# If you see an error 'http://www.3.org...: parser error', read the comments in Makefile
+    # it's because w3.org's web server failed to serve you the needed xsd.
+    # run it again or switch network and run it again. It might be w3's anti-ddos gateway
+	xmllint --noout --schema ../../schema/tokenscript.xsd $@.xml
     # weiwu: xmlstarlet can do validation too, but always outputs nothing for me
     # xmlstarlet val --xsd ../../schema/tokenscript.xsd $^
-	xmllint --noout --schema ../../schema/tokenscript.xsd $@.xml
 	mv $@.xml $@
 ticket: AdmissionTicket.tsml 

--- a/examples/ticket/cards/token.en.shtml
+++ b/examples/ticket/cards/token.en.shtml
@@ -1,6 +1,6 @@
 <script type="text/javascript">
-      ;(function() {
-'use strict'
+  ;(function() {
+  'use strict'
 
     function pad2(num) {
       if (num &lt; 10) return '0' + num
@@ -92,9 +92,10 @@
     } else {
       window.GeneralizedTime = GeneralizedTime
     }
-}())
-
-    class Token {
+  }())
+</script>
+<script type="text/javascript"><![CDATA[
+  class Token {
     constructor(tokenInstance) {
     this.props = tokenInstance
     }
@@ -144,15 +145,12 @@
       </div>`;
     return result
     }
-    }
-    </script>
+  }
     
-    <script>
-      web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
+  web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
         const currentTokenInstance = web3.tokens.data.currentInstance
         const domHtml = new Token(currentTokenInstance).render()
         document.getElementById('root').innerHTML = domHtml
-      }
-</script>
-    
+  }
+]]></script>
 <div id="root"></div>


### PR DESCRIPTION
Solves Boon's issue #88 with the minimum change to his code. Since he already used html entity over CDATA in a few places, I can't just re-introduce `CDATA` overall, but instead, I segmented `<script>` into 2, one use CDATA and the other not. @hboon please do local testing before merging as I don't have the test environment.