### PR TITLE
Tweak styles in example to use standard font used in mobile app

### DIFF
--- a/examples/ticket/cards/shared.css
+++ b/examples/ticket/cards/shared.css
@@ -1,33 +1,35 @@
-    .tbml-count {
-    font-family: "SourceSansPro-Bold";
-    font-weight: bolder;
-    font-size: 21px;
-    color: rgb(47, 187, 79);
-    }
-    .tbml-category {
-    font-family: 'Roboto', sans-serif;
-    font-weight: 300;
-    font-size: 21px;
-    color: rgb(37, 37, 37);
-    }
-    .tbml-venue {
-    font-family: 'Roboto', sans-serif;
-    font-weight: 300;
-    font-size: 12px;
-    color: rgb(0, 0, 0);
-    }
-    .tbml-date {
-    font-family: "SourceSansPro-Semibold";
-    font-weight: bold;
-    font-size: 16px;
-    color: rgb(112, 112, 112);
-    }
-    .tbml-time {
-    font-family: "SourceSansPro-Light";
-    font-weight: lighter;
-    font-size: 16px;
-    color: rgb(112, 112, 112);
-    }
+	.tbml-count {
+	  font-family: "SourceSansPro";
+	  font-weight: bolder;
+	  font-size: 21px;
+	  color: rgb(117, 185, 67);
+	}
+	.tbml-category {
+	  font-family: "SourceSansPro";
+	  font-weight: lighter;
+	  font-size: 21px;
+	  color: rgb(67, 67, 67);
+	}
+	.tbml-venue {
+	  font-family: "SourceSansPro";
+	  font-weight: lighter;
+	  font-size: 16px;
+	  color: rgb(67, 67, 67);
+	}
+	.tbml-date {
+	  font-family: "SourceSansPro";
+	  font-weight: bold;
+	  font-size: 14px;
+	  color: rgb(112, 112, 112);
+	  margin-left: 7px;
+	  margin-right: 7px;
+	}
+	.tbml-time {
+	  font-family: "SourceSansPro";
+	  font-weight: lighter;
+	  font-size: 16px;
+	  color: rgb(112, 112, 112);
+	}
     html {
     }
     

--- a/examples/ticket/cards/token.en.shtml
+++ b/examples/ticket/cards/token.en.shtml
@@ -140,7 +140,7 @@
           <span class="tbml-date">${date}</span>
         </div>
         <div>
-          <span class="tbml-time">${time}</span>  (<span>${this.props.locality}</span>)
+          <span class="tbml-time">${time}, ${this.props.locality}</span>
         </div>
       </div>`;
     return result


### PR DESCRIPTION
* Modify styles to that we use SourceSansPro instead of mixing Roboto. Our native apps only uses SourceSansPro.
* Also restore styles so that they look close to our ticket layout
* Tweak margins in first line to separate count and name

Looks like this (like our tickets):

![Simulator Screen Shot - iPhone X - 2019-04-07 at 16 55 46](https://user-images.githubusercontent.com/56189/55681205-0526d000-5956-11e9-99b5-36122bd68934.png)
