### PR TITLE
Dai+schema 2019/05

### DIFF
--- a/examples/dai/Makefile
+++ b/examples/dai/Makefile
@@ -1,0 +1,31 @@
+XMLSECTOOL=xmlsectool
+KEYSTORE=shong.wang.p12
+KEY=1
+KEYPASSWORD=shong.wang
+SIGNATURE_ALGORITHM=rsa-sha256
+
+help:
+	# Needs a target, example: $$ make AdmissionTicket.canonicalized.xml
+	#  
+	# Let's say you have a TokenScript "AdmissionTicket.xml"
+	#- to validate and canonicalize, add 'canonicalized' in the filename
+	@echo $$ make AdmissionTicket.canonicalized.xml
+	# - to sign, use tsml as file extension:
+	@echo $$ make AdmissionTicket.tsml
+
+%.canonicalized.xml : %.xml
+    # xmlsectool canonicalises automatically when needed, but leaving an xml:base attribute which creates trouble later.
+    # xmlstarlet does it neatly
+	# XML Canonicalization
+	xmlstarlet c14n $^  > $@
+    # xmlsectool validates too, albeit adding xml:base with breaks schema. Example:
+    # JVMOPTS=-Djavax.xml.accessExternalDTD=all /opt/xmlsectool-2.0.0/xmlsectool.sh --validateSchema --xsd --schemaDirectory ../../schema --inFile $^
+	# XML Validation
+    # if failed, run validation again with xmllint to get meaningful error
+    # then delete the canonicalized file
+	-xmlstarlet val --xsd ../../schema/tokenscript.xsd $@ || (xmllint --noout --schema ../../schema/tokenscript.xsd $@; rm $@)
+
+%.tsml: %.canonicalized.xml
+	$(XMLSECTOOL) --sign --keyInfoKeyName 'Shong Wang' --digest SHA-256 --signatureAlgorithm http://www.w3.org/2001/04/xmldsig-more#$(SIGNATURE_ALGORITHM) --inFile $^ --outFile $@ --keystore $(KEYSTORE) --keystoreType PKCS12 --key $(KEY) --keyPassword $(KEYPASSWORD) --signaturePosition LAST
+	# removing the canonicalized created for validation
+	rm $^

--- a/examples/dai/dai.xml
+++ b/examples/dai/dai.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!DOCTYPE tokenscript  [
+<!DOCTYPE token  [
         <!ENTITY style SYSTEM "shared.css">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2019/05/tokenscript"

--- a/examples/dai/dai.xml
+++ b/examples/dai/dai.xml
@@ -31,7 +31,7 @@
                 <ts:name xml:lang="zh">代幣金額</ts:name>
                 <ts:origins>
                     <!-- e18 is a hard coded multiplier.
-                    avoiding over-design when there is no identified needs -->
+                    rationale for hardcoding: avoiding over-design  -->
                     <ts:user-entry as="e18"/>
                 </ts:origins>
             </ts:attribute-type>
@@ -50,7 +50,7 @@
             <ts:origins>
                 <ts:ethereum-function name="balanceOf" contract="dai">
                     <ts:inputs>
-                        <ts:uint256 ref="walletAddress"/>
+                        <ts:uint256 ref="ownerAddress"/>
                     </ts:inputs>
                 </ts:ethereum-function>
             </ts:origins>

--- a/examples/dai/dai.xml
+++ b/examples/dai/dai.xml
@@ -13,10 +13,10 @@
         <ts:string xml:lang="en">DAI</ts:string>
         <ts:string xml:lang="zh">代幣</ts:string>
     </ts:name>
-    <ts:contract label="dai" interface="erc20">
+    <ts:contract name="dai" interface="erc20">
         <ts:address network="1">0xdecafbad1</ts:address>
     </ts:contract>
-    <ts:contract label="dai-bridge">
+    <ts:contract name="dai-bridge">
         <ts:address network="1">0xdecafbad2</ts:address>
     </ts:contract>
     <ts:origins>
@@ -57,6 +57,10 @@
     </ts:cards>
     <ts:attribute-types>
         <ts:attribute-type id="balance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
+            <ts:name>
+                <ts:string xml:lang="en">Balance</ts:string>
+                <ts:string xml:lang="zh">餘額</ts:string>
+            </ts:name>
             <ts:origins>
                 <ts:ethereum function="balanceOf" contract="dai">
                     <ts:inputs>

--- a/examples/dai/dai.xml
+++ b/examples/dai/dai.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE tokenscript  [
+        <!ENTITY style SYSTEM "shared.css">
+        ]>
+<ts:token xmlns:ts="http://tokenscript.org/2019/05/tokenscript"
+          xmlns="http://www.w3.org/1999/xhtml"
+          xmlns:xml="http://www.w3.org/XML/1998/namespace"
+          xsi:schemaLocation="http://tokenscript.org/2019/05/tokenscript ../../schema/tokenscript.xsd"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          custodian="false"
+>
+    <ts:name xml:lang="en">DAI</ts:name>
+    <ts:name xml:lang="zh">代幣</ts:name>
+    <ts:contract interface="erc20" label="dai">
+        <ts:address network="1"></ts:address>
+    </ts:contract>
+    <ts:cards>
+        <ts:token-card>
+            <ts:view-iconified/>
+            <ts:view>
+                <div id="dai"/>
+            </ts:view>
+        </ts:token-card>
+        <ts:action>
+            <ts:name xml:lang="en">Transfer to xDAI</ts:name>
+            <ts:attribute-type id="amount" syntax="1.3.6.1.4.1.1466.115.121.1.36">
+                <ts:name xml:lang="en">Amount in DAI</ts:name>
+                <ts:name xml:lang="zh">代幣金額</ts:name>
+                <ts:origins></ts:origins>
+            </ts:attribute-type>
+            <ts:view/>
+        </ts:action>
+    </ts:cards>
+    <ts:attribute-types>
+        <ts:attribute-type id="balance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
+            <ts:origins>
+                <ts:ethereum-function name="balanceOf" contract="dai">
+                    <ts:inputs>
+                        <ts:uint256 ref="walletAddress"/>
+                    </ts:inputs>
+                </ts:ethereum-function>
+            </ts:origins>
+        </ts:attribute-type>
+    </ts:attribute-types>
+</ts:token>

--- a/examples/dai/dai.xml
+++ b/examples/dai/dai.xml
@@ -11,14 +11,17 @@
 >
     <ts:name xml:lang="en">DAI</ts:name>
     <ts:name xml:lang="zh">代幣</ts:name>
-    <ts:contract interface="erc20" label="dai">
-        <ts:address network="1"></ts:address>
+    <ts:contract label="dai" interface="erc20">
+        <ts:address network="1">0xdecafbad1</ts:address>
+    </ts:contract>
+    <ts:contract label="dai-bridge">
+        <ts:address network="1">0xdecafbad2</ts:address>
     </ts:contract>
     <ts:cards>
         <ts:token-card>
             <ts:view-iconified/>
             <ts:view>
-                <div id="dai"/>
+                <div id="dai-balance"/>
             </ts:view>
         </ts:token-card>
         <ts:action>
@@ -26,8 +29,19 @@
             <ts:attribute-type id="amount" syntax="1.3.6.1.4.1.1466.115.121.1.36">
                 <ts:name xml:lang="en">Amount in DAI</ts:name>
                 <ts:name xml:lang="zh">代幣金額</ts:name>
-                <ts:origins></ts:origins>
+                <ts:origins>
+                    <!-- e18 is a hard coded multiplier.
+                    avoiding over-design when there is no identified needs -->
+                    <ts:user-entry as="e18"/>
+                </ts:origins>
             </ts:attribute-type>
+            <ts:transaction>
+                <ts:ethereum-function name="dai-bridge" contract="dai-bridge">
+                    <ts:inputs>
+                        <ts:uint256 ref="amount"/>
+                    </ts:inputs>
+                </ts:ethereum-function>
+            </ts:transaction>
             <ts:view/>
         </ts:action>
     </ts:cards>

--- a/examples/dai/dai.xml
+++ b/examples/dai/dai.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE token  [
-        <!ENTITY style SYSTEM "shared.css">
-        ]>
+    <!ENTITY style SYSTEM "shared.css">
+    ]>
 <ts:token xmlns:ts="http://tokenscript.org/2019/05/tokenscript"
           xmlns="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -9,8 +9,10 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           custodian="false"
 >
-    <ts:name xml:lang="en">DAI</ts:name>
-    <ts:name xml:lang="zh">代幣</ts:name>
+    <ts:name>
+        <ts:string xml:lang="en">DAI</ts:string>
+        <ts:string xml:lang="zh">代幣</ts:string>
+    </ts:name>
     <ts:contract label="dai" interface="erc20">
         <ts:address network="1">0xdecafbad1</ts:address>
     </ts:contract>
@@ -29,10 +31,14 @@
             </ts:view>
         </ts:token-card>
         <ts:action>
-            <ts:name xml:lang="en">Transfer to xDAI</ts:name>
+            <ts:name>
+                <ts:string xml:lang="en">Transfer to xDAI</ts:string>
+            </ts:name>
             <ts:attribute-type id="amount" syntax="1.3.6.1.4.1.1466.115.121.1.36">
-                <ts:name xml:lang="en">Amount in DAI</ts:name>
-                <ts:name xml:lang="zh">代幣金額</ts:name>
+                <ts:name>
+                    <ts:string xml:lang="en">Amount in DAI</ts:string>
+                    <ts:string xml:lang="zh">代幣金額</ts:string>
+                </ts:name>
                 <ts:origins>
                     <!-- e18 is a hard coded multiplier.
                     rationale for hardcoding: avoiding over-design  -->

--- a/examples/dai/dai.xml
+++ b/examples/dai/dai.xml
@@ -17,6 +17,10 @@
     <ts:contract label="dai-bridge">
         <ts:address network="1">0xdecafbad2</ts:address>
     </ts:contract>
+    <ts:origins>
+        <ts:ethereum contract="dai">
+        </ts:ethereum>
+    </ts:origins>
     <ts:cards>
         <ts:token-card>
             <ts:view-iconified/>
@@ -36,11 +40,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum-function name="dai-bridge" contract="dai-bridge">
+                <ts:ethereum function="dai-bridge" contract="dai-bridge">
                     <ts:inputs>
                         <ts:uint256 ref="amount"/>
                     </ts:inputs>
-                </ts:ethereum-function>
+                </ts:ethereum>
             </ts:transaction>
             <ts:view/>
         </ts:action>
@@ -48,11 +52,11 @@
     <ts:attribute-types>
         <ts:attribute-type id="balance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
             <ts:origins>
-                <ts:ethereum-function name="balanceOf" contract="dai">
+                <ts:ethereum function="balanceOf" contract="dai">
                     <ts:inputs>
                         <ts:uint256 ref="ownerAddress"/>
                     </ts:inputs>
-                </ts:ethereum-function>
+                </ts:ethereum>
             </ts:origins>
         </ts:attribute-type>
     </ts:attribute-types>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -45,7 +45,7 @@
         <xs:element minOccurs="0" ref="interface"/>
       </xs:sequence>
       <xs:attribute name="label" type="xs:ID"/>
-      <xs:attribute name="interface" use="required" type="xs:NCName"/>
+      <xs:attribute name="interface" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="interface" type="xs:NCName"/>
@@ -71,6 +71,7 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="name"/>
         <xs:element minOccurs="0" ref="attribute-type"/>
+        <xs:element minOccurs="0" ref="transaction"/>
         <xs:element minOccurs="0" ref="exclude"/>
         <xs:element minOccurs="0" ref="xhtml:style"/>
         <xs:element ref="view"/>
@@ -187,12 +188,25 @@
       <xs:attribute name="syntax" use="required" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
+  <xs:element name="transaction">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="1">
+        <xs:element ref="ethereum-function"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="origins">
     <xs:complexType>
       <xs:all>
         <xs:element minOccurs="0" ref="ethereum-function"/>
+        <xs:element minOccurs="0" ref="user-entry"/>
         <xs:element minOccurs="0" ref="token-id"/>
       </xs:all>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="user-entry">
+    <xs:complexType>
+      <xs:attribute name="as" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="token-id">

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -23,7 +23,7 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="name"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="contract"/>
-        <xs:element maxOccurs="1" ref="origins"/>
+        <xs:element ref="origins"/>
         <xs:element minOccurs="0" ref="selections"/>
         <xs:element ref="cards"/>
         <xs:element minOccurs="0" ref="grouping"/>
@@ -35,7 +35,14 @@
   </xs:element>
   <xs:element name="name">
     <xs:complexType mixed="true">
-      <xs:attribute ref="xml:lang"/>
+      <xs:sequence>
+      <xs:element maxOccurs="unbounded" ref="string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="string">
+    <xs:complexType>
+      <xs:attribute use="required" ref="xml:lang"/>
       <xs:attribute name="form" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -33,23 +33,41 @@
       <xs:attribute name="custodian" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="name">
-    <xs:complexType mixed="true">
-      <xs:sequence>
+  <xs:element name="name" type="text"/>
+  <xs:complexType name="text" mixed="true">
+    <xs:choice>
       <xs:element maxOccurs="unbounded" ref="string"/>
+      <xs:element maxOccurs="unbounded" ref="plurals"/>
+    </xs:choice>
+  </xs:complexType>
+  <xs:element name="plurals">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="string"/>
       </xs:sequence>
+      <xs:attribute use="required" ref="xml:lang"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="string">
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base="xs:string">
-          <xs:attribute use="required" ref="xml:lang"/>
-          <xs:attribute name="form" type="xs:NCName"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="quantity" type="quantity"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
+  <xs:simpleType name="quantity">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="zero" />
+      <xs:enumeration value="one" />
+      <xs:enumeration value="two" />
+      <xs:enumeration value="few" />
+      <xs:enumeration value="many" />
+      <xs:enumeration value="other" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:element name="contract">
     <xs:complexType>
       <xs:sequence>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -22,7 +22,8 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="name"/>
-        <xs:element maxOccurs="unbounded" ref="contract"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="contract"/>
+        <xs:element maxOccurs="1" ref="origins"/>
         <xs:element minOccurs="0" ref="selections"/>
         <xs:element ref="cards"/>
         <xs:element minOccurs="0" ref="grouping"/>
@@ -41,7 +42,11 @@
   <xs:element name="contract">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="address"/>
+        <xs:element maxOccurs="unbounded" name="address">
+          <xs:complexType mixed="true">
+            <xs:attribute name="network" use="required" type="xs:integer"/>
+          </xs:complexType>
+        </xs:element>
         <xs:element minOccurs="0" ref="interface"/>
       </xs:sequence>
       <xs:attribute name="label" type="xs:ID"/>
@@ -218,54 +223,39 @@
   <xs:element name="ethereum-function">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="inputs"/>
+        <xs:element name="inputs">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="uint256">
+                <xs:complexType >
+                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
       </xs:sequence>
       <xs:attribute name="contract" type="xs:IDREF"/>
       <xs:attribute name="name" use="required" type="xs:NCName"/>
       <xs:attribute name="as" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="inputs">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="uint256"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="uint256">
-    <xs:complexType>
-      <xs:attribute name="ref" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
   <xs:element name="mapping">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="option"/>
+        <xs:element maxOccurs="unbounded" name="option">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" name="value">
+                <xs:complexType mixed="true">
+                  <xs:attribute ref="xml:lang"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="key" use="required" type="xs:integer"/>
+          </xs:complexType>
+        </xs:element>
       </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="option">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="value"/>
-      </xs:sequence>
-      <xs:attribute name="key" use="required" type="xs:integer"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="value">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="xml:lang" use="optional" />
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="address">
-    <xs:complexType mixed="true">
-      <xs:attribute name="network" use="required" type="xs:integer"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="message">
-    <xs:complexType mixed="true">
-      <xs:attribute ref="xml:lang" use="optional" />
-      <xs:attribute name="type" use="required" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -196,14 +196,14 @@
   <xs:element name="transaction">
     <xs:complexType>
       <xs:choice minOccurs="1" maxOccurs="1">
-        <xs:element ref="ethereum-function"/>
+        <xs:element ref="ethereum"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>
   <xs:element name="origins">
     <xs:complexType>
       <xs:all>
-        <xs:element minOccurs="0" ref="ethereum-function"/>
+        <xs:element minOccurs="0" ref="ethereum"/>
         <xs:element minOccurs="0" ref="user-entry"/>
         <xs:element minOccurs="0" ref="token-id"/>
       </xs:all>
@@ -220,7 +220,7 @@
       <xs:attribute name="bitmask"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="ethereum-function">
+  <xs:element name="ethereum">
     <xs:complexType>
       <xs:sequence>
         <xs:element name="inputs">
@@ -236,7 +236,7 @@
         </xs:element>
       </xs:sequence>
       <xs:attribute name="contract" type="xs:IDREF"/>
-      <xs:attribute name="name" use="required" type="xs:NCName"/>
+      <xs:attribute name="function" type="xs:NCName"/>
       <xs:attribute name="as" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -21,7 +21,7 @@
   <xs:element name="token">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="name"/>
+        <xs:element ref="name"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="contract"/>
         <xs:element ref="origins"/>
         <xs:element minOccurs="0" ref="selections"/>
@@ -42,8 +42,12 @@
   </xs:element>
   <xs:element name="string">
     <xs:complexType>
-      <xs:attribute use="required" ref="xml:lang"/>
-      <xs:attribute name="form" type="xs:NCName"/>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute use="required" ref="xml:lang"/>
+          <xs:attribute name="form" type="xs:NCName"/>
+        </xs:extension>
+      </xs:simpleContent>
     </xs:complexType>
   </xs:element>
   <xs:element name="contract">
@@ -56,7 +60,7 @@
         </xs:element>
         <xs:element minOccurs="0" ref="interface"/>
       </xs:sequence>
-      <xs:attribute name="label" type="xs:ID"/>
+      <xs:attribute name="name" type="xs:ID"/>
       <xs:attribute name="interface" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
@@ -81,7 +85,7 @@
   <xs:element name="action">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="name"/>
+        <xs:element ref="name"/>
         <xs:element minOccurs="0" ref="attribute-type"/>
         <xs:element minOccurs="0" ref="transaction"/>
         <xs:element minOccurs="0" ref="exclude"/>
@@ -126,7 +130,7 @@
   <xs:element name="selection">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="name"/>
+        <xs:element ref="name"/>
         <xs:element ref="filter"/>
       </xs:sequence>
       <xs:attribute name="id" use="required" type="xs:NCName"/>
@@ -190,8 +194,8 @@
     <xs:complexType>
       <xs:sequence>
         <!-- name is not needed if the attribute is only used for selection -->
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="name"/>
-        <xs:element minOccurs="1" maxOccurs="unbounded" ref="origins"/>
+        <xs:element minOccurs="0" ref="name"/>
+        <xs:element ref="origins"/>
         <xs:element minOccurs="0" ref="mapping"/>
       </xs:sequence>
       <xs:attribute name="as" type="xs:NCName"/>
@@ -230,7 +234,7 @@
   <xs:element name="ethereum">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="inputs">
+        <xs:element minOccurs="0" name="inputs">
           <xs:complexType>
             <xs:sequence>
               <xs:element name="uint256">

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-           targetNamespace="http://tokenscript.org/2019/04/tokenscript"
+           targetNamespace="http://tokenscript.org/2019/05/tokenscript"
            xmlns:xhtml="http://www.w3.org/1999/xhtml"
-           xmlns="http://tokenscript.org/2019/04/tokenscript">
+           xmlns="http://tokenscript.org/2019/05/tokenscript">
 
 
   <!-- Importing XML namespace for xml:lang and xml:id -->
@@ -23,12 +23,13 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="name"/>
         <xs:element maxOccurs="unbounded" ref="contract"/>
-        <xs:element ref="selections"/>
+        <xs:element minOccurs="0" ref="selections"/>
         <xs:element ref="cards"/>
         <xs:element minOccurs="0" ref="grouping"/>
         <xs:element minOccurs="0" ref="ordering"/>
         <xs:element ref="attribute-types"/>
       </xs:sequence>
+      <xs:attribute name="custodian" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="name">
@@ -43,7 +44,7 @@
         <xs:element maxOccurs="unbounded" ref="address"/>
         <xs:element minOccurs="0" ref="interface"/>
       </xs:sequence>
-      <xs:attribute name="id" type="xs:NCName"/>
+      <xs:attribute name="label" type="xs:ID"/>
       <xs:attribute name="interface" use="required" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
@@ -69,11 +70,11 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="name"/>
+        <xs:element minOccurs="0" ref="attribute-type"/>
         <xs:element minOccurs="0" ref="exclude"/>
         <xs:element minOccurs="0" ref="xhtml:style"/>
         <xs:element ref="view"/>
       </xs:sequence>
-
     </xs:complexType>
   </xs:element>
   <xs:element name="include" type="xs:NCName"/>
@@ -177,7 +178,8 @@
       <xs:sequence>
         <!-- name is not needed if the attribute is only used for selection -->
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="name"/>
-        <xs:element minOccurs="1" maxOccurs="unbounded" ref="origin"/>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="origins"/>
+        <xs:element minOccurs="0" ref="mapping"/>
       </xs:sequence>
       <xs:attribute name="as" type="xs:NCName"/>
       <xs:attribute name="id" use="required" type="xs:NCName"/>
@@ -185,23 +187,28 @@
       <xs:attribute name="syntax" use="required" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="origin">
+  <xs:element name="origins">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="function"/>
-        <xs:element minOccurs="0" ref="mapping"/>
-      </xs:sequence>
-      <xs:attribute name="as" type="xs:NCName"/>
-      <xs:attribute name="bitmask"/>
-      <xs:attribute name="contract" type="xs:NCName"/>
+      <xs:all>
+        <xs:element minOccurs="0" ref="ethereum-function"/>
+        <xs:element minOccurs="0" ref="token-id"/>
+      </xs:all>
     </xs:complexType>
   </xs:element>
-  <xs:element name="function">
+  <xs:element name="token-id">
+    <xs:complexType>
+      <xs:attribute name="as" type="xs:NCName"/>
+      <xs:attribute name="bitmask"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ethereum-function">
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="inputs"/>
       </xs:sequence>
+      <xs:attribute name="contract" type="xs:IDREF"/>
       <xs:attribute name="name" use="required" type="xs:NCName"/>
+      <xs:attribute name="as" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="inputs">


### PR DESCRIPTION
The new schema has these features 𝑛𝑒𝑒𝑑𝑒𝑑 in supporting DAI

1. introduces `<string>` and `<plurals>` element in `<name>`, for localising complex strings.
2. introduces `name="xxx"` attribute for `<contract>` to allow more than 1 contracts.
3. introduces `<origins>` element to contain origins of tokens and attribute-types, in solving #115
4. introduce `<user-entry>` element to contain attribute value sourced from user's entry.
5. replace `<origin function="xxx">` with `<etherem function="xx"`
6. replace `<origin bitmask="xxx">` with `<token-id bitmask="xxx"`
7. introduce `<transaction>` in `<action>`
8. allow `<attribute-type>` in `<action>`
9. use `e18` to solve #116

Given the number of changes we need to do in this sprint (verifying signature, using the new repo server) I feel we should not be handling `<ethereum event="xxx"` in this release.