### PR TITLE
Normalise TokenId

### DIFF
--- a/examples/ticket/EntryToken.xml
+++ b/examples/ticket/EntryToken.xml
@@ -87,7 +87,7 @@
       <ts:origins>
         <ts:ethereum function="getLocality" contract="EntryToken">
             <ts:inputs>
-              <ts:uint256 ref="tokenID"/>
+              <ts:uint256 ref="tokenId"/>
             </ts:inputs>
         </ts:ethereum>
       </ts:origins>
@@ -106,7 +106,7 @@
       <ts:origins>
         <ts:ethereum function="isExpired" contract="EntryToken">
           <ts:inputs>
-            <ts:uint256 ref="tokenID"/>
+            <ts:uint256 ref="tokenId"/>
           </ts:inputs>
         </ts:ethereum>
       </ts:origins>
@@ -123,7 +123,7 @@
       <ts:origins>
         <ts:ethereum function="getStreet" contract="EntryToken">
           <ts:inputs>
-            <ts:uint256 ref="tokenID"/>
+            <ts:uint256 ref="tokenId"/>
           </ts:inputs>
         </ts:ethereum>
       </ts:origins>
@@ -132,7 +132,7 @@
       <ts:origins>
         <ts:ethereum function="getBuildingName" contract="EntryToken">
           <ts:inputs>
-            <ts:uint256 ref="tokenID"/>
+            <ts:uint256 ref="tokenId"/>
           </ts:inputs>
         </ts:ethereum>
       </ts:origins>
@@ -141,7 +141,7 @@
       <ts:origins>
         <ts:ethereum function="getState" contract="EntryToken">
           <ts:inputs>
-            <ts:uint256 ref="tokenID"/>
+            <ts:uint256 ref="tokenId"/>
           </ts:inputs>
         </ts:ethereum>
       </ts:origins>


### PR DESCRIPTION
Ensure standard symbols are consistent across scripts - tokenId (Java style syntax) is used in dai.xml whereas tokenID is used in EntryToken.xml.

tokenId seems more normalised than tokenID. Whichever way, we should be consistent.