### PR TITLE
correctly implement constants in smart contract call declaration

### DIFF
--- a/examples/erc20/DAI.xml
+++ b/examples/erc20/DAI.xml
@@ -51,20 +51,11 @@
                     <ts:user-entry as="e18"/>
                 </ts:origins>
             </ts:attribute-type>
-            <ts:attribute-type id="recipient" syntax="1.3.6.1.4.1.1466.115.121.1.36">
-                <ts:name>
-                    <ts:string xml:lang="en">recipient</ts:string>
-                    <ts:string xml:lang="zh">recipient</ts:string>
-                </ts:name>
-                <ts:origins>
-                </ts:origins>
-            </ts:attribute-type>
             <ts:transaction>
-                <!-- convert erc20 DAI to native xDAI -->
-                <!-- simply send dai to 0x4aa42145Aa6Ebf72e164C9bBC74fbD3788045016 -->
                 <ts:ethereum function="transfer" contract="dai">
                     <ts:inputs>
-                        <ts:address ref="recipient"/>
+                        <!-- to convert erc20 DAI to native xDAI, transfer to this address -->
+                        <ts:address>0x4aa42145Aa6Ebf72e164C9bBC74fbD3788045016</ts:address>
                         <ts:uint256 ref="amount"/>
                     </ts:inputs>
                 </ts:ethereum>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -231,11 +231,11 @@
   </xs:element>
   <xs:element name="origins">
     <xs:complexType>
-      <xs:all>
-        <xs:element minOccurs="0" ref="ethereum"/>
-        <xs:element minOccurs="0" ref="user-entry"/>
-        <xs:element minOccurs="0" ref="token-id"/>
-      </xs:all>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="ethereum"/>
+        <xs:element ref="user-entry"/>
+        <xs:element ref="token-id"/>
+      </xs:choice>
     </xs:complexType>
   </xs:element>
   <xs:element name="user-entry">
@@ -256,498 +256,498 @@
           <xs:complexType>
             <xs:choice maxOccurs="unbounded">
               <xs:element name="uint8">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint16">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint24">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint32">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint40">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint48">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint56">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint64">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint72">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint80">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint88">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint96">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint104">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint112">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint120">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint128">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint136">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint144">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint152">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint160">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint168">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint176">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint184">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint192">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint200">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint208">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint216">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint224">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint232">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint240">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint248">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="uint256">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int8">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int16">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int24">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int32">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int40">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int48">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int56">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int64">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int72">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int80">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int88">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int96">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int104">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int112">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int120">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int128">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int136">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int144">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int152">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int160">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int168">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int176">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int184">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int192">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int200">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int208">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int216">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int224">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int232">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int240">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int248">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="int256">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="address">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="string">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="byte">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes2">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes3">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes4">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes5">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes6">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes7">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes8">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes9">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes10">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes11">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes12">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes13">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes14">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes15">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes16">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes17">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes18">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes19">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes20">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes21">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes22">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes23">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes24">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes25">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes26">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes27">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes28">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes29">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes30">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes31">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="bytes32">
-                <xs:complexType >
-                  <xs:attribute name="ref" use="required" type="xs:NCName"/>
+                <xs:complexType mixed="true">
+                  <xs:attribute name="ref" type="xs:NCName"/>
                 </xs:complexType>
               </xs:element>
             </xs:choice>


### PR DESCRIPTION
I feel this version is ready for dai->xdai bridge, but @James-Sangalli please have a look why there are unused contracts like `dai-bridge-mainnet` and `xdai-converter-address`? If they are useless, kindly delete them before approving.