### PR TITLE
Fix: make DAI example display DAI balance correctly

### DIFF
--- a/examples/erc20/dai-bridge.en.shtml
+++ b/examples/erc20/dai-bridge.en.shtml
@@ -17,7 +17,12 @@
 	<p><input type="number" name="xdaiBridge"/><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAoCAYAAACfKfiZAAAABGdBTUEAALGPC/xhBQAAAcNJREFUWAntl71KxEAQx03OyuJSiIKtCIIfT+ATiOnEsxMld6X2Fgo2PoBgdXfJNT5BtNM7BLGysvQZvM5CuFzifwJzjHf5uLBbbiDszO7M/H87bGBjLZQ8vu9vxXEcWpb14HnedUl4utzpdB6TJDmQsch/ajabrpwj256ekH6v19sej8cDFFsHxBUK38r1AnszYy1rLh+AxEejUR+FVrkYQC4rQHBa4ZjZAYjsRFE0kOJcRTfEDACJQ6wPoRUWnR51QvwDCIJgt0ycYXRBTABIHAfupWjnLM6jDogUIAzDpariEqLb7XrsVx0XKcF13V987/fY0bIo4MA+EX5q4nv+RNwrz9u2ncD+YL/qmAKgaIzEG5mMw7gBoRkAEm+1WhcyVsWenAGVIiq5BsB0wHTAdMB0wHTAdMB0wHTAdCC9FatcKtvt9jHy92QN3JxnfutoDrF3Mg638XdlABQ5QvFDWTjHpv+Mc7mGvDXlM1Cv108B8SYLz2NTjuM4Z8oAjUbjBxD7VSAolnIoVxmAdlsFQopTrhaAeSGmxbUClEFkiWsHyIPIEy8EqNVq30gcUhA/8BO8X+znjXwmsP5MLx+4rPg/qL3E8KLnDDoAAAAASUVORK5CYII=" style="display: inline;" height="25" alt="xDai Bridge"/></p>
 </form>
 <script type="text/javascript">
-    var correctedBalance = web3.tokens.data.currentInstance.balance / 10e+18;
-	document.getElementById('daiVal').innerHTML = correctedBalance;
-	document.getElementById("xDaiVal").innerHTML = 0; //TODO get this as native balance
+  web3.tokens.dataChanged = (oldTokens, updatedTokens) => {
+    const currentTokenInstance = web3.tokens.data.currentInstance
+    if (currentTokenInstance.balance != null) {
+      var correctedBalance = currentTokenInstance.balance / 1e+18;
+      document.getElementById('daiVal').innerHTML = correctedBalance;
+    }
+    document.getElementById("xDaiVal").innerHTML = 0; //TODO get this as native balance
+  }
 </script>


### PR DESCRIPTION
Before applying this PR, the DAI example:

* computed the balance wrongly (used `10e18`. Should be `1e18`)
* couldn't display the balance because the data may not be immediately available upon the first time it's rendered