### PR TITLE
Xdai bridge action

### DIFF
--- a/examples/action/Makefile
+++ b/examples/action/Makefile
@@ -1,0 +1,38 @@
+XMLSECTOOL=xmlsectool
+KEYSTORE=
+KEY=1
+KEYPASSWORD=
+SIGNATURE_ALGORITHM=rsa-sha256
+
+help:
+	# Needs a target, example: $$ make AdmissionTicket.canonicalized.xml
+	#  
+	# Let's say you have a TokenScript "AdmissionTicket.xml"
+	#- to validate and canonicalize, add 'canonicalized' in the filename
+	@echo $$ make AdmissionTicket.canonicalized.xml
+	# - to sign, use tsml as file extension:
+	@echo $$ make AdmissionTicket.tsml
+
+%.canonicalized.xml : %.xml
+    # xmlsectool canonicalises automatically when needed, but leaving an xml:base attribute which creates trouble later.
+    # xmlstarlet does it neatly
+	# XML Canonicalization
+	xmlstarlet c14n $^  > $@
+    # xmlsectool validates too, albeit adding xml:base with breaks schema. Example:
+    # JVMOPTS=-Djavax.xml.accessExternalDTD=all /opt/xmlsectool-2.0.0/xmlsectool.sh --validateSchema --xsd --schemaDirectory ../../schema --inFile $^
+	# XML Validation
+    # if failed, run validation again with xmllint to get meaningful error
+    # then delete the canonicalized file
+	-xmlstarlet val --xsd ../../schema/tokenscript.xsd $@ || (xmllint --noout --schema ../../schema/tokenscript.xsd $@; rm $@)
+
+%.tsml: %.canonicalized.xml
+ifeq (,$(KEYSTORE))
+	@echo ---------------- Keystore missing. Try this ---------------- 
+	@echo $$ make KEYSTORE=shong.wang.p12 KEYPASSWORD=shong.wang $@
+	@echo replace it with your .p12 file and your password
+	rm $^
+else
+	$(XMLSECTOOL) --sign --keyInfoKeyName 'Shong Wang' --digest SHA-256 --signatureAlgorithm http://www.w3.org/2001/04/xmldsig-more#$(SIGNATURE_ALGORITHM) --inFile $^ --outFile $@ --keystore $(KEYSTORE) --keystoreType PKCS12 --key $(KEY) --keyPassword $(KEYPASSWORD) --signaturePosition LAST
+	# removing the canonicalized created for validation
+	rm $^
+endif

--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -21,7 +21,17 @@
             </ts:contract>
         </ts:token>
     </ts:output>
-
+    <ts:attribute-type id="amount" syntax="1.3.6.1.4.1.1466.115.121.1.36">
+        <ts:name>
+            <ts:string xml:lang="en">Amount</ts:string>
+            <ts:string xml:lang="zh">代幣金額</ts:string>
+        </ts:name>
+        <ts:origins>
+            <!-- e18 is a hard coded multiplier.
+            rationale for hardcoding: avoiding over-design  -->
+            <ts:user-entry as="e18"/>
+        </ts:origins>
+    </ts:attribute-type>
     <!-- if the user tries to use this action when having little xdai
          balance, either by clicking this action under the XDAI's
          token view, or by clicking "create" token and choosing DAI,
@@ -40,6 +50,7 @@
     <ts:transaction>
         <ts:ethereum>
             <ts:to>0xdecafbad</ts:to>
+            <ts:value ref="amount"/>
         </ts:ethereum>
     </ts:transaction>
 

--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -17,7 +17,7 @@
     <ts:output>
         <ts:token name="dai">
             <ts:contract>
-                <ts:address network="1">0xdecafbad</ts:address>
+                <ts:address network="1">0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359</ts:address>
             </ts:contract>
         </ts:token>
     </ts:output>
@@ -49,7 +49,7 @@
 
     <ts:transaction>
         <ts:ethereum>
-            <ts:to>0xdecafbad</ts:to>
+            <ts:to>0x7301CFA0e1756B71869E93d4e4Dca5c7d0eb0AA6</ts:to>
             <ts:value ref="amount"/>
         </ts:ethereum>
     </ts:transaction>

--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -8,7 +8,7 @@
          an action under XDAI's token view. -->
     <ts:input>
         <ts:token name="xdai">
-            <ts:currency network="100"/>
+            <ts:ethereum network="100"/>
         </ts:token>
     </ts:input>
     <!-- because this action has DAI as output, when a user decides to
@@ -26,12 +26,16 @@
          balance, either by clicking this action under the XDAI's
          token view, or by clicking "create" token and choosing DAI,
          the following message shows. -->
+    <!-- The exclusion rule here is excluded out to reduce the scope of schema-2019-05
     <ts:exclude>
-        <ts:selection filter="balance<=1000000000"/>
+        <ts:selection>
+            <ts:token filter="balance<=1000000000"/>
+        </ts:selection>
         <ts:message>
             <ts:string xml:lang="en">Not enough balance.</ts:string>
         </ts:message>
     </exclude>
+    -->
 
     <ts:transaction>
         <ts:ethereum>

--- a/examples/action/XDAI.xml
+++ b/examples/action/XDAI.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ts:action xmlns:ts="http://tokenscript.org/2019/05/tokenscript"
+           xmlns="http://www.w3.org/1999/xhtml"
+           xmlns:xml="http://www.w3.org/XML/1998/namespace"
+>
+    <ts:name>Transfer xDAI to DAI</ts:name>
+    <!-- because this action has xdai as input, it should be listed as
+         an action under XDAI's token view. -->
+    <ts:input>
+        <ts:token name="xdai">
+            <ts:currency network="100"/>
+        </ts:token>
+    </ts:input>
+    <!-- because this action has DAI as output, when a user decides to
+         create a new token, this action qallows DAI token to be chosen as
+         the new token to create -->
+    <ts:output>
+        <ts:token name="dai">
+            <ts:contract>
+                <ts:address network="1">0xdecafbad</ts:address>
+            </ts:contract>
+        </ts:token>
+    </ts:output>
+
+    <!-- if the user tries to use this action when having little xdai
+         balance, either by clicking this action under the XDAI's
+         token view, or by clicking "create" token and choosing DAI,
+         the following message shows. -->
+    <ts:exclude>
+        <ts:selection filter="balance<=1000000000"/>
+        <ts:message>
+            <ts:string xml:lang="en">Not enough balance.</ts:string>
+        </ts:message>
+    </exclude>
+
+    <ts:transaction>
+        <ts:ethereum>
+            <ts:to>0xdecafbad</ts:to>
+        </ts:ethereum>
+    </ts:transaction>
+
+    <ts:view/>
+</ts:action>

--- a/examples/erc20/DAI.xml
+++ b/examples/erc20/DAI.xml
@@ -41,15 +41,6 @@
                     <ts:user-entry as="e18"/>
                 </ts:origins>
             </ts:attribute-type>
-            <ts:transaction>
-                <ts:ethereum function="transfer" contract="dai">
-                    <ts:data>
-                        <!-- to convert erc20 DAI to native xDAI, transfer to this address -->
-                        <ts:address>0x7301CFA0e1756B71869E93d4e4Dca5c7d0eb0AA6</ts:address>
-                        <ts:uint256 ref="amount"/>
-                    </ts:data>
-                </ts:ethereum>
-            </ts:transaction>
             <ts:view>&dai-bridge.en;</ts:view>
         </ts:action>
         <ts:action>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -5,641 +5,662 @@
            xmlns="http://tokenscript.org/2019/05/tokenscript">
 
 
-  <!-- Importing XML namespace for xml:lang and xml:id -->
-  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
-        schemaLocation="xml.xsd" />
+    <!-- Importing XML namespace for xml:lang and xml:id -->
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+               schemaLocation="xml.xsd"/>
 
-  <!-- Importing XML Signature namespace. Schema is from
-      http://www.w3.org/TR/2008/REC-xmldsig-core-20080610/xmldsig-core-schema.xsd
-  -->
-  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#"
-        schemaLocation="xmldsig-core-schema.xsd" />
+    <!-- Importing XML Signature namespace. Schema is from
+        http://www.w3.org/TR/2008/REC-xmldsig-core-20080610/xmldsig-core-schema.xsd
+    -->
+    <xs:import namespace="http://www.w3.org/2000/09/xmldsig#"
+               schemaLocation="xmldsig-core-schema.xsd"/>
 
-  <!-- Importing XHTML namespace. use xhtml1-strict.xsd to get xhtml:Block -->
-  <xs:import namespace="http://www.w3.org/1999/xhtml"
-             schemaLocation="xhtml1-strict.xsd"/>
-  <xs:element name="token">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="name"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="contract"/>
-        <xs:element ref="origins"/>
-        <xs:element minOccurs="0" ref="selections"/>
-        <xs:element ref="cards"/>
-        <xs:element minOccurs="0" ref="grouping"/>
-        <xs:element minOccurs="0" ref="ordering"/>
-        <xs:element ref="attribute-types"/>
-      </xs:sequence>
-      <xs:attribute name="custodian" type="xs:boolean"/>
+    <!-- Importing XHTML namespace. use xhtml1-strict.xsd to get xhtml:Block -->
+    <xs:import namespace="http://www.w3.org/1999/xhtml"
+               schemaLocation="xhtml1-strict.xsd"/>
+    
+    <xs:element name="token">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="name"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="contract"/>
+                <xs:element ref="origins"/>
+                <xs:element minOccurs="0" ref="selections"/>
+                <xs:element ref="cards"/>
+                <xs:element minOccurs="0" ref="grouping"/>
+                <xs:element minOccurs="0" ref="ordering"/>
+                <xs:element ref="attribute-types"/>
+            </xs:sequence>
+            <xs:attribute name="custodian" type="xs:boolean"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="action">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="name"/>
+                <xs:element minOccurs="0" name="input" type="tokens"/>
+                <xs:element minOccurs="0" name="output" type="tokens"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="attribute-type"/>
+                <xs:element minOccurs="0" ref="exclude"/>
+                <xs:element minOccurs="0" ref="transaction"/>
+                <xs:element minOccurs="0" ref="xhtml:style"/>
+                <xs:element minOccurs="0" ref="view"/><!-- default constructed view -->
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="tokens">
+        <xs:choice maxOccurs="unbounded" minOccurs="0">
+            <xs:element name="token">
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element name="ethereum">
+                            <xs:complexType>
+                                <xs:attribute name="network"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element ref="contract"/>
+                    </xs:choice>
+                    <xs:attribute name="name" type="xs:ID"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
     </xs:complexType>
-  </xs:element>
-  <xs:element name="name" type="text"/>
-  <xs:complexType name="text" mixed="true">
-    <xs:sequence>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="plurals"/>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="plurals">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="string"/>
-      </xs:sequence>
-      <xs:attribute use="required" ref="xml:lang"/>
+    <xs:element name="name" type="text"/>
+    <xs:element name="message" type="text"/>
+    <xs:complexType name="text" mixed="true">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="plurals"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="string"/>
+        </xs:sequence>
     </xs:complexType>
-  </xs:element>
-  <xs:element name="string">
-    <xs:complexType>
-      <xs:simpleContent>
-        <xs:extension base="xs:string">
-          <xs:attribute ref="xml:lang"/>
-          <xs:attribute name="quantity" type="quantity"/>
-        </xs:extension>
-      </xs:simpleContent>
+    <xs:element name="plurals">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="string"/>
+            </xs:sequence>
+            <xs:attribute use="required" ref="xml:lang"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="string">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute ref="xml:lang"/>
+                    <xs:attribute name="quantity" type="quantity"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="quantity">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="zero"/>
+            <xs:enumeration value="one"/>
+            <xs:enumeration value="two"/>
+            <xs:enumeration value="few"/>
+            <xs:enumeration value="many"/>
+            <xs:enumeration value="other"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="contract">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" name="address">
+                    <xs:complexType mixed="true">
+                        <xs:attribute name="network" use="required" type="xs:integer"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element minOccurs="0" ref="interface"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:ID"/>
+            <xs:attribute name="interface" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="interface" type="xs:NCName"/>
+    <xs:element name="cards">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="token-card"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="action"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="token-card">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="xhtml:style"/>
+                <xs:element minOccurs="0" ref="view-iconified"/>
+                <xs:element minOccurs="0" ref="view"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="include" type="xs:NCName"/>
+    <xs:element name="view" type="shtml"/>
+    <xs:element name="view-iconified" type="shtml">
+    </xs:element>
+    <xs:complexType name="shtml">
+        <xs:complexContent>
+            <xs:extension base="xhtml:Block">
+                <xs:attributeGroup ref="xhtml:attrs"/>
+                <xs:attribute name="onload" type="xhtml:Script"/>
+                <xs:attribute name="onunload" type="xhtml:Script"/>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
-  </xs:element>
-  <xs:simpleType name="quantity">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="zero" />
-      <xs:enumeration value="one" />
-      <xs:enumeration value="two" />
-      <xs:enumeration value="few" />
-      <xs:enumeration value="many" />
-      <xs:enumeration value="other" />
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:element name="contract">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" name="address">
-          <xs:complexType mixed="true">
-            <xs:attribute name="network" use="required" type="xs:integer"/>
-          </xs:complexType>
-        </xs:element>
-        <xs:element minOccurs="0" ref="interface"/>
-      </xs:sequence>
-      <xs:attribute name="name" type="xs:ID"/>
-      <xs:attribute name="interface" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="interface" type="xs:NCName"/>
-  <xs:element name="cards">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="token-card"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="action"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="token-card">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="xhtml:style"/>
-        <xs:element ref="view-iconified"/>
-        <xs:element ref="view"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="action">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="name"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="attribute-type"/>
-        <xs:element minOccurs="0" ref="transaction"/>
-        <xs:element minOccurs="0" ref="exclude"/>
-        <xs:element minOccurs="0" ref="xhtml:style"/>
-        <xs:element ref="view"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="include" type="xs:NCName"/>
-  <xs:element name="view" type="shtml"/>
-  <xs:element name="view-iconified" type="shtml">
-  </xs:element>
-  <xs:complexType name="shtml">
-    <xs:complexContent>
-      <xs:extension base="xhtml:Block">
-        <xs:attributeGroup ref="xhtml:attrs"/>
-        <xs:attribute name="onload" type="xhtml:Script"/>
-        <xs:attribute name="onunload" type="xhtml:Script"/>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:element name="redeem">
-    <xs:complexType>
-      <xs:attribute name="format" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="exclude">
-    <xs:complexType>
-      <xs:attribute name="selection"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="feemaster" type="xs:anyURI"/>
-  <xs:element name="gateway" type="xs:anyURI"/>
-  <xs:element name="prefix" type="xs:anyURI"/>
-  <xs:element name="selections">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="selection"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="selection">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="name"/>
-        <xs:element ref="filter"/>
-      </xs:sequence>
-      <xs:attribute name="id" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="filter" type="xs:string"/>
-  <xs:element name="grouping">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="group"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="group">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="consecutive_groups"/>
-      </xs:sequence>
-      <xs:attribute name="bitmask" use="required"/>
-      <xs:attribute name="name" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="consecutive_groups">
-    <xs:complexType/>
-  </xs:element>
-  <xs:element name="ordering">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="order"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="order">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="byName"/>
-        <xs:element maxOccurs="unbounded" ref="byValue"/>
-      </xs:sequence>
-      <xs:attribute name="bitmask" use="required"/>
-      <xs:attribute name="name" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="byName">
-    <xs:complexType>
-      <xs:attribute name="field" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="byValue">
-    <xs:complexType>
-      <xs:attribute name="field" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="attribute-types">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="attribute-type"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="attribute-type">
-    <xs:complexType>
-      <xs:sequence>
-        <!-- name is not needed if the attribute is only used for selection -->
-        <xs:element minOccurs="0" ref="name"/>
-        <xs:element ref="origins"/>
-      </xs:sequence>
-      <xs:attribute name="id" use="required" type="xs:NCName"/>
-      <xs:attribute name="oid" type="xs:NMTOKEN"/>
-      <xs:attribute name="syntax" use="required" type="xs:NMTOKEN"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:simpleType name="syntax">
-    <xs:restriction base="xs:NMTOKEN">
-      <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.7"/><!-- Boolean -->
-      <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.15"/><!-- DirectoryString -->
-      <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.24"/><!-- GeneralizedTime -->
-      <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.26"/><!-- IA5String -->
-      <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.27"/><!-- Integer -->
-      <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.36"/><!-- NumericString -->
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:element name="transaction">
-    <xs:complexType>
-      <xs:choice>
-        <xs:element ref="ethereum"/>
-      </xs:choice>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="origins">
-    <xs:complexType>
-      <xs:choice maxOccurs="unbounded">
-        <xs:element ref="ethereum"/>
-        <xs:element ref="user-entry"/>
-        <xs:element ref="token-id"/>
-      </xs:choice>
-    </xs:complexType>
-  </xs:element>
-  <xs:simpleType name="as">
-  <xs:restriction base="xs:NCName">
-    <xs:enumeration value="uint" />
-    <xs:enumeration value="address" />
-    <!-- int is not allowed here, because "as" is not for typing but for transforming  -->
-    <xs:enumeration value="utf8" />
-    <xs:enumeration value="e18" />
-    <xs:enumeration value="bool"/>
-  </xs:restriction>
-</xs:simpleType>
-  <xs:element name="user-entry">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="mapping"/>
-      </xs:sequence>
-      <xs:attribute name="as" type="as" use="required"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="token-id">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" ref="mapping"/>
-      </xs:sequence>
-      <xs:attribute name="as" type="as" use="required"/>
-      <xs:attribute name="bitmask"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="ethereum">
-    <xs:complexType>
-      <xs:choice maxOccurs="2">
-        <xs:element minOccurs="0" name="value">
-          <xs:complexType mixed="true">
-            <xs:attribute name="ref" type="xs:NCName"/>
-          </xs:complexType>
-        </xs:element>
-        <xs:element name="to" type="address"/>
-        <xs:element name="data">
-          <xs:complexType>
-            <xs:choice maxOccurs="unbounded">
-              <xs:element name="uint8">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint16">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint24">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint32">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint40">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint48">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint56">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint64">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint72">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint80">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint88">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint96">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint104">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint112">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint120">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint128">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint136">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint144">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint152">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint160">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint168">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint176">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint184">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint192">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint200">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint208">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint216">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint224">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint232">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint240">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint248">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="uint256">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int8">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int16">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int24">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int32">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int40">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int48">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int56">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int64">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int72">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int80">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int88">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int96">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int104">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int112">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int120">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int128">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int136">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int144">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int152">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int160">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int168">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int176">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int184">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int192">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int200">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int208">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int216">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int224">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int232">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int240">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int248">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="int256">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="string">
-                <xs:complexType mixed="true">
-                  <xs:attribute name="ref" type="xs:NCName"/>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="address" type="address"/>
+    <xs:element name="redeem">
+        <xs:complexType>
+            <xs:attribute name="format" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="exclude">
+        <xs:complexType>
+            <xs:attribute name="selection"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="feemaster" type="xs:anyURI"/>
+    <xs:element name="gateway" type="xs:anyURI"/>
+    <xs:element name="prefix" type="xs:anyURI"/>
+    <xs:element name="selections">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="selection"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="selection">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="name"/>
+                <xs:element ref="filter"/>
+            </xs:sequence>
+            <xs:attribute name="id" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="filter" type="xs:string"/>
+    <xs:element name="grouping">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="group"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="group">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="consecutive_groups"/>
+            </xs:sequence>
+            <xs:attribute name="bitmask" use="required"/>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="consecutive_groups">
+        <xs:complexType/>
+    </xs:element>
+    <xs:element name="ordering">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="order"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="order">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="byName"/>
+                <xs:element maxOccurs="unbounded" ref="byValue"/>
+            </xs:sequence>
+            <xs:attribute name="bitmask" use="required"/>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="byName">
+        <xs:complexType>
+            <xs:attribute name="field" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="byValue">
+        <xs:complexType>
+            <xs:attribute name="field" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="attribute-types">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="attribute-type"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="attribute-type">
+        <xs:complexType>
+            <xs:sequence>
+                <!-- name is not needed if the attribute is only used for selection -->
+                <xs:element minOccurs="0" ref="name"/>
+                <xs:element ref="origins"/>
+            </xs:sequence>
+            <xs:attribute name="id" use="required" type="xs:NCName"/>
+            <xs:attribute name="oid" type="xs:NMTOKEN"/>
+            <xs:attribute name="syntax" use="required" type="xs:NMTOKEN"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="syntax">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.7"/><!-- Boolean -->
+            <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.15"/><!-- DirectoryString -->
+            <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.24"/><!-- GeneralizedTime -->
+            <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.26"/><!-- IA5String -->
+            <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.27"/><!-- Integer -->
+            <xs:enumeration value="1.3.6.1.4.1.1466.115.121.1.36"/><!-- NumericString -->
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="transaction">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element ref="ethereum"/>
             </xs:choice>
-          </xs:complexType>
-        </xs:element>
-        <xs:element minOccurs="0" ref="mapping"/>
-      </xs:choice>
-      <xs:attribute name="contract" type="xs:IDREF"/>
-      <xs:attribute name="function" type="xs:NCName"/>
-      <xs:attribute name="as" type="as"/>
-    </xs:complexType>
-  </xs:element>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="origins">
+        <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element ref="ethereum"/>
+                <xs:element ref="user-entry"/>
+                <xs:element ref="token-id"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="as">
+        <xs:restriction base="xs:NCName">
+            <xs:enumeration value="uint"/>
+            <xs:enumeration value="address"/>
+            <!-- int is not allowed here, because "as" is not for typing but for transforming  -->
+            <xs:enumeration value="utf8"/>
+            <xs:enumeration value="e18"/>
+            <xs:enumeration value="bool"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="user-entry">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="mapping"/>
+            </xs:sequence>
+            <xs:attribute name="as" type="as" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="token-id">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="mapping"/>
+            </xs:sequence>
+            <xs:attribute name="as" type="as" use="required"/>
+            <xs:attribute name="bitmask"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="ethereum">
+        <xs:complexType>
+            <xs:choice maxOccurs="2">
+                <xs:element minOccurs="0" name="value">
+                    <xs:complexType mixed="true">
+                        <xs:attribute name="ref" type="xs:NCName"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="to" type="address"/>
+                <xs:element name="data">
+                    <xs:complexType>
+                        <xs:choice maxOccurs="unbounded">
+                            <xs:element name="uint8">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint16">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint24">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint32">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint40">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint48">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint56">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint64">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint72">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint80">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint88">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint96">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint104">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint112">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint120">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint128">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint136">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint144">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint152">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint160">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint168">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint176">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint184">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint192">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint200">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint208">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint216">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint224">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint232">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint240">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint248">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="uint256">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int8">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int16">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int24">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int32">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int40">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int48">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int56">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int64">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int72">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int80">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int88">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int96">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int104">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int112">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int120">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int128">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int136">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int144">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int152">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int160">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int168">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int176">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int184">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int192">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int200">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int208">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int216">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int224">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int232">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int240">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int248">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="int256">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="string">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute name="ref" type="xs:NCName"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="address" type="address"/>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element minOccurs="0" ref="mapping"/>
+            </xs:choice>
+            <xs:attribute name="contract" type="xs:IDREF"/>
+            <xs:attribute name="function" type="xs:NCName"/>
+            <xs:attribute name="as" type="as"/>
+        </xs:complexType>
+    </xs:element>
     <xs:complexType name="address" mixed="true">
-      <xs:attribute name="ref" type="xs:NCName"/>
+        <xs:attribute name="ref" type="xs:NCName"/>
     </xs:complexType>
     <xs:element name="mapping">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" name="option">
-          <xs:complexType>
+        <xs:complexType>
             <xs:sequence>
-              <xs:element maxOccurs="unbounded" name="value">
-                <xs:complexType mixed="true">
-                  <xs:attribute ref="xml:lang"/>
-                </xs:complexType>
-              </xs:element>
+                <xs:element maxOccurs="unbounded" name="option">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element maxOccurs="unbounded" name="value">
+                                <xs:complexType mixed="true">
+                                    <xs:attribute ref="xml:lang"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="key" use="required" type="xs:integer"/>
+                    </xs:complexType>
+                </xs:element>
             </xs:sequence>
-            <xs:attribute name="key" use="required" type="xs:integer"/>
-          </xs:complexType>
-        </xs:element>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>


### PR DESCRIPTION
Before reading the changes, get familiar with the term I invented. I call changing the definition of existing elements or attributes with a new pull request to a tokenscript 𝑑𝑟𝑖𝑓𝑡𝑖𝑛𝑔. Schema changes should be of its own PR at a monthly interval.

The changes from the previous one demonstrated to you guys were:

1. `<exclude>` rules are excluded here because it begets some schema drifting and it made the target bigger.
2. change in `<token>` element:
````
    <ts:input>
        <ts:token name="xdai">
            <ts:currency network="100"/>
        </ts:token>
    </ts:input>
````
has become:
````
     <ts:input>
        <ts:token name="xdai">
            <ts:ethereum network="100"/>
        </ts:token>
    </ts:input>
````
Because I intend to make stuff specific to Ethereum with an element that has `ethereum` keyword. The same change, in the same spirit, should be applied to the `contract` element but I choose not to make that change to avoid schema drifting.

