### PR TITLE
forbid the use of <name> without sub-elements

### DIFF
--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -3,7 +3,10 @@
            xmlns="http://www.w3.org/1999/xhtml"
            xmlns:xml="http://www.w3.org/XML/1998/namespace"
 >
-    <ts:name>Transfer xDAI to DAI</ts:name>
+    <ts:name>
+        <ts:string xml:lang="en">Transfer xDAI to DAI</ts:string>
+        <ts:string xml:lang="zh">將xDAI轉爲DAI</ts:string>
+    </ts:name>
     <!-- because this action has xdai as input, it should be listed as
          an action under XDAI's token view. -->
     <ts:input>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -67,20 +67,19 @@
     </xs:complexType>
     <xs:element name="name" type="text"/>
     <xs:element name="message" type="text"/>
-    <xs:complexType name="text" mixed="true">
+    <xs:complexType name="text">
         <xs:sequence>
-            <xs:element minOccurs="0" maxOccurs="unbounded" ref="plurals"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded"  name="plurals">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" ref="string"/>
+                    </xs:sequence>
+                    <xs:attribute use="required" ref="xml:lang"/>
+                </xs:complexType>
+            </xs:element>
             <xs:element minOccurs="0" maxOccurs="unbounded" ref="string"/>
         </xs:sequence>
     </xs:complexType>
-    <xs:element name="plurals">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element maxOccurs="unbounded" ref="string"/>
-            </xs:sequence>
-            <xs:attribute use="required" ref="xml:lang"/>
-        </xs:complexType>
-    </xs:element>
     <xs:element name="string">
         <xs:complexType>
             <xs:simpleContent>


### PR DESCRIPTION
the <name> tag inconsistency is fixed by updating schema.

 In all other tokenscript the action name is defined similar to this:

<ts:name>
<ts:string xml:lang="en">Enter</ts:string>
<ts:string xml:lang="zh">入場</ts:string>
<ts:string xml:lang="es">Entrar</ts:string>
</ts:name>

Whereas here it's:

<ts:name>Transfer xDAI to DAI</ts:name>

Replaced with something like this

<ts:name>
<ts:string xml:lang="en">Convert xAW to awDai</ts:string>
</ts:name>