### PR TITLE
𝑐𝑜𝑛𝑡𝑟𝑜𝑣𝑒𝑟𝑠𝑦: using the Digest instead of file hash for express-of-trust

### DIFF
--- a/doc/security.md
+++ b/doc/security.md
@@ -1,4 +1,5 @@
-# Security of TokenScript files
+## Security of TokenScript files
+(This is not the security of TokenScript - which is a separate topic)
 
 A TokenScript file can be signed. A TokenScript can also be trusted. Ideally, all TokenScript's are signed and trusted.
 
@@ -34,7 +35,9 @@ The express-of-trust special address is calculated in this way:
 
 Assume that TokenScript project's donation address' public key is known, which is Y. In multiplicative group notation, its value is gˣ where 𝑥 is the private key held by TokenScript administration.
 
-First, we do a Keccak hash of the TokenScript file and get *s*. Then compute *h=H("TRUST"|s)* where *H* denotes Keccak, | is used to denote concatenation and the text *TRUST* is simply an ASCII encoding of the literal word TRUST.
+First, we obtain a SHA256 digest 𝑑 from the exclusive canonicalization of the TokenScript. If this TokenScript happens to be signed as well, and the `<DigestMethod>`  used for its root is SHA256 (it usually is), you can find the value encoded in base64 in the `<DigestValue>`. (Of course, you need to decode the base64 value before use.)
+
+Then compute *h=H("TRUST"|𝑑)* where *H* denotes Keccak. `|` is used to denote concatenation. The text *TRUST* is simply an ASCII encoding of the literal word TRUST.
 
 Then, we generate the secp256k1 elliptic curve point Yʰ, and hash it to get an address. This is the special address for express-of-trust of this specific TokenScript.
 


### PR DESCRIPTION
This pull request can stay for a week or two until we are sure of it.

My question: which one is more important, consistency or simplicity?

If you choose simplicity, the express-of-trust address should be created from the hash of the TokenScript file. This is the simplest a noob programmer can do and he can do so with keccak without touching outlandish† hash methods like SHA256

† outlandish - to the eyes of someone who learned nothing else about cryptography except those used in Ethereum

If you choose consistency, the express-of-trust address should be created from the digest of the canonicalized root element of the TokenScript. The downside is that the hash method has to be agreed on before (can't be keccak because XMLSIG doesn't support it), so we fixed it to SHA256. The upside is that it also allows constructed TokenScript to be trusted‡.

‡ Constructed TokenScript is made by merging multiple TokenScript actions into one big chunk, useful for web developers to choose what component action he needs instead of providing the full TokenScript of 200KB, or to mish-mesh actions from different authors. Each component has to be trusted through an express-of-trust transaction for the entire constructed TokenScript to be trusted.

This pull request opts for consistency (@hboon suggested so) and as you can see from the diff, such is not straightforward to implement.