### PR TITLE
Shorten title for action of xDai bridge

### DIFF
--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -8,7 +8,7 @@
            xmlns:xml="http://www.w3.org/XML/1998/namespace"
 >
     <ts:name>
-        <ts:string xml:lang="en">Transfer xDAI to DAI</ts:string>
+        <ts:string xml:lang="en">Transfer to DAI</ts:string>
         <ts:string xml:lang="zh">將xDAI轉爲DAI</ts:string>
     </ts:name>
     <!-- because this action has xdai as input, it should be listed as


### PR DESCRIPTION
This PR changes it to "Transfer to DAI".

Screenshot below is generated with a recent commit to the TokenScript branch which adds some left and right margin to long titles:

<img src="https://user-images.githubusercontent.com/56189/59161891-f3f76c80-8b1a-11e9-98ed-36c082000531.png" width=200 />