### PR TITLE
moving etheruem calls to its own namespace

### DIFF
--- a/schema/ethereum.xsd
+++ b/schema/ethereum.xsd
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+           elementFormDefault="qualified"
            xmlns="urn:ethereum:constantinople"
            targetNamespace="urn:ethereum:constantinople">
+
+    <xs:import schemaLocation="tokenscript.xsd" namespace="http://tokenscript.org/2020/06/tokenscript"/>
+
     <xs:simpleType name="data-type">
         <xs:restriction base="xs:string">
             <xs:enumeration value="bool"/>
@@ -111,4 +116,47 @@
     </xs:simpleType>
     <xs:attribute name="type" type="data-type"/>
     <xs:attribute name="indexed" type="xs:boolean" default="false"/>
+
+    <xs:complexType name="address" mixed="true">
+        <xs:attribute name="ref" type="xs:NCName"/>
+    </xs:complexType>
+
+    <xs:element name="call">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" name="ether">
+                    <xs:complexType mixed="true">
+                        <xs:attribute name="ref" type="xs:NCName"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element minOccurs="0" ref="ts:data"/>
+                <xs:element minOccurs="0" ref="ts:mapping"/>
+            </xs:sequence>
+            <xs:attribute name="as" type="ts:as"/>
+            <xs:attribute name="bitmask" type="ts:bitmask"/>
+            <xs:attribute name="contract" type="xs:IDREF"/>
+            <xs:attribute name="function" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="transfer">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" name="to" type="ts:address"/>
+                <xs:element minOccurs="0" name="ether">
+                    <xs:complexType mixed="true">
+                        <xs:attribute name="ref" type="xs:NCName"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="event">
+        <xs:complexType>
+            <!-- TODO: this should be whatever ASN.X allows as element name -->
+            <xs:attribute name="module" type="xs:NCName"/>
+            <xs:attribute name="filter" type="xs:string"/>
+            <xs:attribute name="select" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -5,6 +5,7 @@
            xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"
            xmlns="http://tokenscript.org/2020/06/tokenscript"
            xmlns:asnx="urn:ietf:params:xml:ns:asnx"
+           xmlns:ethereum="urn:ethereum:constantinople"
            elementFormDefault="qualified">
 
     <!-- Importing XML namespace for xml:lang and xml:id -->
@@ -24,6 +25,9 @@
     <xs:import namespace="urn:ietf:params:xml:ns:asnx"
                schemaLocation="asnx.xsd"/>
 
+    <xs:import namespace="urn:ethereum:constantinople"
+               schemaLocation="ethereum.xsd"/>
+
     <xs:include schemaLocation="data.xsd"/> <!-- soon to be replaced by data objects -->
     
     <xs:element name="token">
@@ -31,7 +35,13 @@
             <xs:sequence>
                 <xs:element name="name" type="text"/>
                 <xs:element minOccurs="0" maxOccurs="unbounded" ref="contract"/>
-                <xs:element ref="origins"/>
+                <xs:element name="origins">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element ref="ethereum" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element minOccurs="0" maxOccurs="unbounded" ref="selection"/>
                 <xs:element ref="cards"/>
                 <xs:element minOccurs="0" ref="grouping"/>
@@ -252,14 +262,16 @@
     <xs:element name="transaction">
         <xs:complexType>
             <xs:choice>
-                <xs:element ref="ethereum"/>
+                <xs:element ref="ethereum:call"/>
+                <xs:element ref="ethereum:transfer"/>
             </xs:choice>
         </xs:complexType>
     </xs:element>
     <xs:element name="origins">
         <xs:complexType>
             <xs:choice maxOccurs="unbounded">
-                <xs:element ref="ethereum"/>
+                <xs:element ref="ethereum:event"/>
+                <xs:element ref="ethereum:call"/>
                 <xs:element ref="user-entry"/>
                 <xs:element ref="token-id"/>
             </xs:choice>


### PR DESCRIPTION
in all cards, all references to ethereum events and calls are reällocated to the ethereum namespace

detail: http://tokenscript.org/2020/06/tokenscript#ethereum-namespace

This needs to be merged in at the same time as https://github.com/AlphaWallet/TokenScript-Examples/pull/73