### PR TITLE
Id and asnx module correction

### DIFF
--- a/schema/asnx.xsd
+++ b/schema/asnx.xsd
@@ -11,12 +11,18 @@
     <element name="module">
         <complexType>
             <choice>
-                <element name="sequence" type="asnx:container"/>
+                <element name="namedType" type="asnx:namedType"/>
             </choice>
             <attribute name="name" type="NCName"/>
         </complexType>
     </element>
 
+    <complexType name="namedType">
+        <choice>
+            <element name="sequence" type="asnx:container"/>
+        </choice>
+        <attribute name="name" type="NCName"/>
+    </complexType>
     <complexType name="container">
         <choice maxOccurs="unbounded">
             <element name="element" type="asnx:element"/>

--- a/schema/ethereum.xsd
+++ b/schema/ethereum.xsd
@@ -128,7 +128,6 @@
                 <xs:element minOccurs="0" ref="ts:mapping"/>
             </xs:sequence>
             <xs:attribute name="as" type="ts:as"/>
-            <xs:attribute name="bitmask" type="ts:bitmask"/>
             <xs:attribute name="contract" type="xs:IDREF"/>
             <xs:attribute name="function" type="xs:NCName"/>
         </xs:complexType>
@@ -154,7 +153,8 @@
     <xs:element name="event">
         <xs:complexType>
             <!-- TODO: this should be whatever ASN.X allows as element name -->
-            <xs:attribute name="module" type="xs:NCName"/>
+            <xs:attribute name="type" type="xs:NCName"/>
+            <xs:attribute name="contract" type="xs:IDREF"/>
             <xs:attribute name="filter" type="xs:string"/>
             <xs:attribute name="select" type="xs:NCName"/>
         </xs:complexType>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -33,6 +33,7 @@
     <element name="token">
         <complexType>
             <sequence>
+                <element ref="asnx:module" minOccurs="0" maxOccurs="unbounded"/>
                 <element name="label" type="ts:text"/>
                 <element minOccurs="0" maxOccurs="unbounded" ref="ts:contract"/>
                 <element name="origins">
@@ -152,7 +153,6 @@
                         <attribute name="network" use="required" type="integer"/>
                     </complexType>
                 </element>
-                <element ref="asnx:module" minOccurs="0" maxOccurs="unbounded"/>
                 <element minOccurs="0" ref="ts:interface"/>
             </sequence>
             <attribute name="name" type="ID"/>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -191,7 +191,7 @@
                 <element minOccurs="0" name="label" type="ts:text"/>
                 <element minOccurs="0" name="denial" type="ts:text"/>
             </sequence>
-            <attribute name="id" type="NCName"/>
+            <attribute name="name" type="NCName"/>
             <attribute name="filter" type="string" use="required"></attribute>
         </complexType>
     </element>


### PR DESCRIPTION
This goes with https://github.com/AlphaWallet/TokenScript-Examples/pull/84

1. `<selection id=` becomes `<selection name=`
2. ASN modules usage corrected to align with RFC4912.