### PR TITLE
allowing contracts to be absent  in ethereum:*

### DIFF
--- a/ERCs/ERC20/ERC20-TokenScript.xml
+++ b/ERCs/ERC20/ERC20-TokenScript.xml
@@ -134,7 +134,7 @@
             <ts:string xml:lang="en">name</ts:string>
         </ts:label>
         <ts:origins>
-            <ethereum:call function="name" contract="ERC20" as="utf8"/>
+            <ethereum:call function="name" as="utf8"/>
         </ts:origins>
     </ts:attribute>
 
@@ -146,7 +146,7 @@
             <ts:string xml:lang="en">balance</ts:string>
         </ts:label>
         <ts:origins>
-            <ethereum:call function="balanceOf" contract="ERC20" as="uint">
+            <ethereum:call function="balanceOf" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
@@ -162,7 +162,7 @@
             <ts:string xml:lang="en">decimals</ts:string>
         </ts:label>
         <ts:origins>
-            <ethereum:call function="decimals" contract="ERC20" as="uint"/>
+            <ethereum:call function="decimals" as="uint"/>
         </ts:origins>
     </ts:attribute>
 
@@ -174,7 +174,7 @@
             <ts:string xml:lang="en">symbol</ts:string>
         </ts:label>
         <ts:origins>
-            <ethereum:call function="symbol" contract="ERC20" as="utf8"/>
+            <ethereum:call function="symbol" as="utf8"/>
         </ts:origins>
     </ts:attribute>
 

--- a/ERCs/ERC721/ERC721-TokenScript.xml
+++ b/ERCs/ERC721/ERC721-TokenScript.xml
@@ -135,7 +135,7 @@
             <ts:string xml:lang="en">name</ts:string>
         </ts:label>
         <ts:origins>
-            <ethereum:call function="name" contract="ERC721" as="utf8"/>
+            <ethereum:call function="name" as="utf8"/>
         </ts:origins>
     </ts:attribute>
 
@@ -147,7 +147,7 @@
             <ts:string xml:lang="en">symbol</ts:string>
         </ts:label>
         <ts:origins>
-            <ethereum:call function="symbol" contract="ERC721" as="utf8"/>
+            <ethereum:call function="symbol" as="utf8"/>
         </ts:origins>
     </ts:attribute>
 


### PR DESCRIPTION
The new default TS files are valid:

````
weiwu@damascus:~/IdeaProjects/TokenScript/ERCs$ TOKENSCRIPT_SCHEMA=/home/weiwu/IdeaProjects/TokenScript/schema/tokenscript.xsd ../examples/validate.sh ERC20/ERC20-TokenScript.xml 
ERC20-TokenScript.canonicalized.xml validates
[Valid]   : ERC20/ERC20-TokenScript.xml
weiwu@damascus:~/IdeaProjects/TokenScript/ERCs$ TOKENSCRIPT_SCHEMA=/home/weiwu/IdeaProjects/TokenScript/schema/tokenscript.xsd ../examples/validate.sh ERC721/ERC721-TokenScript.xml 
ERC721-TokenScript.canonicalized.xml validates
[Valid]   : ERC721/ERC721-TokenScript.xml

````