### PR TITLE
Add origins in activity

### DIFF
--- a/ERCs/ERC20/ERC20-TokenScript.xml
+++ b/ERCs/ERC20/ERC20-TokenScript.xml
@@ -23,7 +23,7 @@
                 <sequence>
                     <element name="owner" ethereum:type="address" ethereum:indexed="true"/>
                     <element name="spender" ethereum:type="address" ethereum:indexed="true"/>
-                    <element name="value" ethereum:type="uint256" ethereum:indexed="false"/>
+                    <element name="amount" ethereum:type="uint256" ethereum:indexed="false"/>
                 </sequence>
             </type>
         </namedType>
@@ -32,7 +32,7 @@
                 <sequence>
                     <element name="from" ethereum:type="address" ethereum:indexed="true"/>
                     <element name="to" ethereum:type="address" ethereum:indexed="true"/>
-                    <element name="value" ethereum:type="uint256" ethereum:indexed="false"/>
+                    <element name="amount" ethereum:type="uint256" ethereum:indexed="false"/>
                 </sequence>
             </type>
         </namedType>
@@ -53,7 +53,7 @@
         </ts:card>
         <ts:card type="activity" name="received">
             <ts:origins>
-                <ethereum:event type="Transfer" filter="to=${ownerAddress}" select="value"/>
+                <ethereum:event type="Transfer" filter="to=${ownerAddress}" />
             </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
@@ -67,7 +67,6 @@
 
         <ts:card type="activity" name="ownerApproved">
             <ts:origins>
-                <!-- this brings in attribute "value" -->
                 <ethereum:event type="Approval" filter="owner=${ownerAddress}"/>
             </ts:origins>
             <ts:attribute name="to">

--- a/ERCs/ERC20/ERC20-TokenScript.xml
+++ b/ERCs/ERC20/ERC20-TokenScript.xml
@@ -19,18 +19,22 @@
 >
     <asnx:module name="ERC20-Events">
         <namedType name="Approval">
-            <sequence>
-                <element name="owner" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="spender" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="value" ethereum:type="uint256" ethereum:indexed="false"/>
-            </sequence>
+            <type>
+                <sequence>
+                    <element name="owner" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="spender" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="value" ethereum:type="uint256" ethereum:indexed="false"/>
+                </sequence>
+            </type>
         </namedType>
         <namedType name="Transfer">
-            <sequence>
-                <element name="from" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="to" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="value" ethereum:type="uint256" ethereum:indexed="false"/>
-            </sequence>
+            <type>
+                <sequence>
+                    <element name="from" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="to" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="value" ethereum:type="uint256" ethereum:indexed="false"/>
+                </sequence>
+            </type>
         </namedType>
     </asnx:module>
     <ts:cards>

--- a/ERCs/ERC20/ERC20-TokenScript.xml
+++ b/ERCs/ERC20/ERC20-TokenScript.xml
@@ -69,14 +69,6 @@
             <ts:origins>
                 <ethereum:event type="Approval" filter="owner=${ownerAddress}"/>
             </ts:origins>
-            <ts:attribute name="to">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="owner=${ownerAddress}" select="spender"/>
-                </ts:origins>
-            </ts:attribute>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script  type="text/javascript">&item-view-ownerApproved.en;</script>

--- a/ERCs/ERC20/ERC20-TokenScript.xml
+++ b/ERCs/ERC20/ERC20-TokenScript.xml
@@ -39,14 +39,9 @@
     </asnx:module>
     <ts:cards>
         <ts:card type="activity" name="sent">
-            <ts:attribute name="amount">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Transfer" filter="from=${ownerAddress}" select="value"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <ethereum:event type="Transfer" filter="from=${ownerAddress}"/>
+            </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script  type="text/javascript">&item-view-sent.en;</script>
@@ -57,14 +52,9 @@
             </ts:view>
         </ts:card>
         <ts:card type="activity" name="received">
-            <ts:attribute name="amount">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Transfer" filter="to=${ownerAddress}" select="value"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <ethereum:event type="Transfer" filter="to=${ownerAddress}" select="value"/>
+            </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script  type="text/javascript">&item-view-received.en;</script>
@@ -76,14 +66,10 @@
         </ts:card>
 
         <ts:card type="activity" name="ownerApproved">
-            <ts:attribute name="amount">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="owner=${ownerAddress}" select="value"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <!-- this brings in attribute "value" -->
+                <ethereum:event type="Approval" filter="owner=${ownerAddress}"/>
+            </ts:origins>
             <ts:attribute name="to">
                 <ts:type>
                     <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
@@ -103,22 +89,9 @@
         </ts:card>
 
         <ts:card type="activity" name="approvalObtained">
-            <ts:attribute name="amount">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="spender=${ownerAddress}" select="value"/>
-                </ts:origins>
-            </ts:attribute>
-            <ts:attribute name="from">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="spender=${ownerAddress}" select="owner"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <ethereum:event type="Approval" filter="spender=${ownerAddress}"/>
+            </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script  type="text/javascript">&item-view-approvalObtained.en;</script>

--- a/ERCs/ERC721/ERC721-TokenScript.xml
+++ b/ERCs/ERC721/ERC721-TokenScript.xml
@@ -19,18 +19,22 @@
 >
     <asnx:module name="ERC721-Events">
         <namedType name="Approval">
-            <sequence>
-                <element name="_owner" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="_approved" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="_tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
-            </sequence>
+            <type>
+                <sequence>
+                    <element name="_owner" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="_approved" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="_tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
+                </sequence>
+            </type>
         </namedType>
         <namedType name="Transfer">
-            <sequence>
-                <element name="_from" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="_to" ethereum:type="address" ethereum:indexed="true"/>
-                <element name="_tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
-            </sequence>
+            <type>
+                <sequence>
+                    <element name="_from" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="_to" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="_tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
+                </sequence>
+            </type>
         </namedType>
     </asnx:module>
     <ts:cards>

--- a/ERCs/ERC721/ERC721-TokenScript.xml
+++ b/ERCs/ERC721/ERC721-TokenScript.xml
@@ -42,7 +42,7 @@
             <ts:origins>
                 <!-- this gives you card attributes from, to, tokenID, which is different than the
                  token's attributes -->
-                <ethereum:event type="Transfer" filter="${from}=${ownerAddress}"/>
+                <ethereum:event type="Transfer" filter="from=${ownerAddress}"/>
             </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
@@ -57,7 +57,7 @@
             <ts:origins>
                 <!-- this gives you card attributes from, to, tokenId, which is different than the
                  token's attributes which also have tokenId -->
-                <ethereum:event type="Transfer" filter="${to}=${ownerAddress}"/>
+                <ethereum:event type="Transfer" filter="to=${ownerAddress}"/>
             </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>

--- a/ERCs/ERC721/ERC721-TokenScript.xml
+++ b/ERCs/ERC721/ERC721-TokenScript.xml
@@ -42,7 +42,7 @@
             <ts:origins>
                 <!-- this gives you card attributes from, to, tokenID, which is different than the
                  token's attributes -->
-                <ethereum:event type="Transfer" filter="${_from}=${ownerAddress}"/>
+                <ethereum:event type="Transfer" filter="${from}=${ownerAddress}"/>
             </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
@@ -57,7 +57,7 @@
             <ts:origins>
                 <!-- this gives you card attributes from, to, tokenId, which is different than the
                  token's attributes which also have tokenId -->
-                <ethereum:event type="Transfer" filter="${_to}=${ownerAddress}"/>
+                <ethereum:event type="Transfer" filter="${to}=${ownerAddress}"/>
             </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
@@ -71,16 +71,8 @@
 
         <ts:card type="activity" name="ownerApproved">
             <ts:origins>
-                <ethereum:event type="Approval" filter="${_from}=${ownerAddress}"/>
+                <ethereum:event type="Approval" filter="${from}=${ownerAddress}"/>
             </ts:origins>
-            <ts:attribute name="to">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="${_to}=${ownerAddress}" select="_to"/>
-                </ts:origins>
-            </ts:attribute>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script type="text/javascript">&item-view-ownerApproved.en;</script>
@@ -93,7 +85,7 @@
 
         <ts:card type="activity" name="approvalObtained">
             <ts:origins>
-                <ethereum:event type="Approval" filter="${_to}=${ownerAddress}"/>
+                <ethereum:event type="Approval" filter="${to}=${ownerAddress}"/>
             </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>

--- a/ERCs/ERC721/ERC721-TokenScript.xml
+++ b/ERCs/ERC721/ERC721-TokenScript.xml
@@ -21,32 +21,29 @@
         <namedType name="Approval">
             <type>
                 <sequence>
-                    <element name="_owner" ethereum:type="address" ethereum:indexed="true"/>
-                    <element name="_approved" ethereum:type="address" ethereum:indexed="true"/>
-                    <element name="_tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
+                    <element name="owner" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="approved" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
                 </sequence>
             </type>
         </namedType>
         <namedType name="Transfer">
             <type>
                 <sequence>
-                    <element name="_from" ethereum:type="address" ethereum:indexed="true"/>
-                    <element name="_to" ethereum:type="address" ethereum:indexed="true"/>
-                    <element name="_tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
+                    <element name="from" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="to" ethereum:type="address" ethereum:indexed="true"/>
+                    <element name="tokenId" ethereum:type="uint256" ethereum:indexed="false"/>
                 </sequence>
             </type>
         </namedType>
     </asnx:module>
     <ts:cards>
         <ts:card type="activity" name="sent">
-            <ts:attribute name="_tokenId">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Transfer" filter="${_from}=${ownerAddress}" select="_tokenId"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <!-- this gives you card attributes from, to, tokenID, which is different than the
+                 token's attributes -->
+                <ethereum:event type="Transfer" filter="${_from}=${ownerAddress}"/>
+            </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script type="text/javascript">&item-view-sent.en;</script>
@@ -57,14 +54,11 @@
             </ts:view>
         </ts:card>
         <ts:card type="activity" name="received">
-            <ts:attribute name="_tokenId">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Transfer" filter="${_to}=${ownerAddress}" select="_tokenId"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <!-- this gives you card attributes from, to, tokenId, which is different than the
+                 token's attributes which also have tokenId -->
+                <ethereum:event type="Transfer" filter="${_to}=${ownerAddress}"/>
+            </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script type="text/javascript">&item-view-received.en;</script>
@@ -76,14 +70,9 @@
         </ts:card>
 
         <ts:card type="activity" name="ownerApproved">
-            <ts:attribute name="_tokenId">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="${_from}=${ownerAddress}" select="_tokenId"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <ethereum:event type="Approval" filter="${_from}=${ownerAddress}"/>
+            </ts:origins>
             <ts:attribute name="to">
                 <ts:type>
                     <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
@@ -103,22 +92,9 @@
         </ts:card>
 
         <ts:card type="activity" name="approvalObtained">
-            <ts:attribute name="_tokenId">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="${_to}=${ownerAddress}" select="_tokenId"/>
-                </ts:origins>
-            </ts:attribute>
-            <ts:attribute name="from">
-                <ts:type>
-                    <ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax>
-                </ts:type>
-                <ts:origins>
-                    <ethereum:event type="Approval" filter="${_to}=${ownerAddress}" select="_from"/>
-                </ts:origins>
-            </ts:attribute>
+            <ts:origins>
+                <ethereum:event type="Approval" filter="${_to}=${ownerAddress}"/>
+            </ts:origins>
             <ts:item-view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
                 <style type="text/css">&style;</style>
                 <script type="text/javascript">&item-view-approvalObtained.en;</script>

--- a/doc/javascript_api.md
+++ b/doc/javascript_api.md
@@ -190,8 +190,8 @@ TokenScript's JavaScript API is designed to be asynchronous.
 
 There are 3 args supplied to the `web3.tokens.dataChanged` callback:
 
-* oldTokens — this contains the value of the token instance before this change
-* updatedTokens — this contains the value of the token instance after this change
+* old data — this contains the data — token instance and card attribute values — before the change
+* updated data — this contains the data — token instance and card attribute values — after the change
 * tokenCardId — the CSS ID of the wrapper `<div>` to place content in
 
 Developers can use this callback and the arguments to figure out what has changed. We might point them to a good JSON-diff library; but since the purpose here is just to render a static layout, they can just re-render the whole DOM as we do in our examples.
@@ -199,10 +199,9 @@ Developers can use this callback and the arguments to figure out what has change
 A simple way to implement that would be:
 
 ```
-web3.tokens.dataChanged = (oldTokens, updatedTokens, tokenCardId) => {
-    const currentTokenInstance = updatedTokens.currentInstance
-    const domHtml = new Token(currentTokenInstance).render()
-    document.getElementById(tokenCardId).getElementsByClassName("contents")[0].innerHTML = domHtml
+web3.tokens.dataChanged = (old, updated, tokenCardId) => {
+    const data = updated
+    document.getElementById(tokenCardId).getElementsByClassName("contents")[0].innerHTML = new Token(data).render()
 }
 ```
 
@@ -215,6 +214,33 @@ document.getElementById(tokenCardId).innerHTML = replacementDomHtml
 ```
 
 The above-mentioned `Token.render()` function generates a DOM from a dictionary of token attributes.
+
+Within the `Token` class, the token data can be access like this:
+
+```
+const tokenAttributeValue = this.props.token.tokenAttribute1
+```
+
+and the card data like this:
+
+```
+const cardAttributeValue = this.props.card.tokenAttribute1
+```
+
+And if we are sure the token and card attribute names don't clash, we can pretend they are in the same namespace with:
+
+```
+web3.tokens.dataChanged = (old, updated, tokenCardId) => {
+    const data = Object.assign({}, updated.token, updated.card)
+    document.getElementById(tokenCardId).getElementsByClassName("contents")[0].innerHTML = new Token(data).render()
+}
+```
+
+Then this is unchanged:
+
+```
+const attributeValue = this.props.tokenAttribute1 //or this.props.cardAttribute1
+```
 
 Future
 ---

--- a/schema/asnx.xsd
+++ b/schema/asnx.xsd
@@ -52,7 +52,7 @@
 
     <complexType name="element">
         <choice>
-            <element name="type" type="asnx:type"/>
+            <element minOccurs="0" name="type" type="asnx:type"/>
         </choice>
         <attribute name="name" type="NCName"/>
         <attribute name="type">

--- a/schema/asnx.xsd
+++ b/schema/asnx.xsd
@@ -19,10 +19,31 @@
 
     <complexType name="namedType">
         <choice>
-            <element name="sequence" type="asnx:container"/>
+            <element name="element" type="asnx:element"/>
+            <element name="type" type="asnx:type">
+            </element>
         </choice>
         <attribute name="name" type="NCName"/>
     </complexType>
+
+    <complexType name="type">
+        <choice>
+            <element name="sequence" type="asnx:container"/>
+            <element name="enumerated" type="asnx:enumerated"/>
+        </choice>
+    </complexType>
+
+    <complexType name="enumerated">
+        <sequence>
+            <element name="enumeration" maxOccurs="unbounded">
+                <complexType>
+                    <attribute name="name" type="NCName"/>
+                    <attribute name="number" type="integer"/>
+                </complexType>
+            </element>
+        </sequence>
+    </complexType>
+
     <complexType name="container">
         <choice maxOccurs="unbounded">
             <element name="element" type="asnx:element"/>
@@ -30,18 +51,22 @@
     </complexType>
 
     <complexType name="element">
+        <choice>
+            <element name="type" type="asnx:type"/>
+        </choice>
         <attribute name="name" type="NCName"/>
-        <attribute name="type" type="asnx:type"/>
+        <attribute name="type">
+            <simpleType>
+                <restriction base="string">
+                    <enumeration value="asnx:UTF8String"/>
+                    <enumeration value="asnx:INTEGER"/>
+                    <enumeration value="asnx:BOOLEAN"/>
+                    <enumeration value="asnx:OCTET-STRING"/>
+                    <enumeration value="asnx:UTCTime"/>
+                </restriction>
+            </simpleType>
+        </attribute>
         <attribute ref="ethereum:type"/>
         <attribute ref="ethereum:indexed"/>
     </complexType>
-
-    <simpleType name="type">
-        <restriction base="string">
-            <enumeration value="asnx:UTF8String"/>
-            <enumeration value="asnx:INTEGER"/>
-            <enumeration value="asnx:BOOLEAN"/>
-            <enumeration value="asnx:OCTET-STRING"/>
-        </restriction>
-    </simpleType>
 </schema>

--- a/schema/ethereum.xsd
+++ b/schema/ethereum.xsd
@@ -153,8 +153,8 @@
     <xs:element name="event">
         <xs:complexType>
             <!-- TODO: this should be whatever ASN.X allows as element name -->
-            <xs:attribute name="type" type="xs:NCName"/>
-            <xs:attribute name="contract" type="xs:IDREF"/>
+            <xs:attribute use="required" name="type" type="xs:NCName"/>
+            <xs:attribute use="required" name="contract" type="xs:IDREF"/>
             <xs:attribute name="filter" type="xs:string"/>
             <xs:attribute name="select" type="xs:NCName"/>
         </xs:complexType>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -58,6 +58,14 @@
             </sequence>
             <attribute name="custodian" type="boolean" default="false"/>
         </complexType>
+        <keyref name="eventTypeRef" refer="ts:namedTypeName">
+            <selector xpath="ts:cards/ts:card/ts:origins/ethereum:event"></selector>
+            <field xpath="@type"></field>
+        </keyref>
+        <key name="namedTypeName">
+            <selector xpath="asnx:module/namedType"></selector>
+            <field xpath="@name"></field>
+        </key>
         <key name="token-attributes">
             <selector xpath="ts:attribute"></selector>
             <field xpath="@name"></field>

--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -67,6 +67,7 @@
         <complexType>
             <sequence>
                 <element minOccurs="0" name="label" type="ts:text"/>
+                <element minOccurs="0" ref="ts:origins"/>
                 <element minOccurs="0" maxOccurs="unbounded" ref="ts:attribute"/>
                 <element minOccurs="0" maxOccurs="unbounded" ref="ts:selection"/>
                 <!-- consider putting input and output in transaction


### PR DESCRIPTION
As per TokenScript weekly meeting #40, developers should base their Activity A3 project on the files provided in ERCs directory. Notice that this is based on PR #365 which will be merged in a few weeks since αW is released with [a fix](https://github.com/AlphaWallet/alpha-wallet-android/pull/1484)

- [x] @hboon is to update the JavaScript in these files to reflect what he proposed in the #40 meeting.