### PR TITLE
Resolved issue - The XPath expression //ts:origins/ethereum:event|//t…

### DIFF
--- a/schema/tokenscript.xsd
+++ b/schema/tokenscript.xsd
@@ -59,7 +59,7 @@
             <attribute name="custodian" type="boolean" default="false"/>
         </complexType>
         <keyref name="typeRef" refer="ts:namedTypeName">
-            <selector xpath="//ts:origins/ethereum:event|//ts:origins/ethereum:call"></selector>
+            <selector xpath=".//ts:origins/ethereum:event|.//ts:origins/ethereum:call"></selector>
             <field xpath="@type"></field>
         </keyref>
         <key name="namedTypeName">


### PR DESCRIPTION
Hi Weiwu,

Please review and accept the changes which resolves the below reported issue.

```
schema/tokenscript.xsd:62: element selector: Schemas parser error :
Element '{http://www.w3.org/2001/XMLSchema}selector', attribute
'xpath': The XPath expression
'//ts:origins/ethereum:event|//ts:origins/ethereum:call' could not be
compiled.
```